### PR TITLE
Fix naerspecies value in aer_wetscav_simple (issue #29), v4.3.3

### DIFF
--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -490,21 +490,24 @@ CONTAINS
       ! be disabled in mozcart_wetscav)
       aer_pointers(:) = (/ p_sulf, p_seas_1, p_seas_2, p_seas_3, &
                         p_seas_4, p_bc2, p_oc2, p_dust_1, &
-                        p_dust_2, p_dust_3, p_dust_4, p_bc1 /)
+                        p_dust_2, p_dust_3, p_dust_4, p_dust_5, &
+                        p_bc1 /)
       ! Fraction of activated aerosols for aer_pointers species, values from
       ! Luo et al. (2020)
-      aq_aer_ratio(:) = (/ 1., 1., 1., 1., 1., 0.5, 0.5, 0., 0., 0., 0., 0. /)
-      ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 0. /)
+      aq_aer_ratio(:) = (/ 1., 1., 1., 1., 1., 0.5, 0.5, 0., 0., 0., 0., 0., 0. /)
+      ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 0. /)
       ! List of washed out fine aerosol for aer_pointers species (r<=1
       ! micrometer)
       aer_is_fine(:) = (/ .true., .true., .true., .false., &
                        .false., .true., .true. , .true., &
-                       .false., .false., .false., .false. /)
+                       .false., .false., .false., .false., &
+                       .false. /)
       ! List of washed out coarse aerosol for aer_pointers species (r>1
       ! micrometer)
       aer_is_coarse(:) = (/ .false., .false., .false., .true., &
                        .true., .false., .false. , .false., &
-                       .true., .true., .true., .false. /)
+                       .true., .true., .true., .true., &
+                       .false. /)
     ELSE
       CALL wrf_error_fatal ('wetscav_simple_init: chem_opt not supported')
     ENDIF

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -457,7 +457,7 @@ CONTAINS
     ! This could be recovered from the aerosol scheme data directly
     IF(chem_opt == MOZCART_KPP) THEN
       ! MOZCART
-      naerspecies = 12
+      naerspecies = 13
     ELSE
       CALL wrf_error_fatal ('wetscav_simple_init: chem_opt not supported')
     ENDIF

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -488,21 +488,21 @@ CONTAINS
       !-- MOZCART
       ! Species that experience wet scavenging (sulfate deposition needs to
       ! be disabled in mozcart_wetscav)
-      aer_pointers = (/ p_sulf, p_seas_1, p_seas_2, p_seas_3, &
+      aer_pointers(:) = (/ p_sulf, p_seas_1, p_seas_2, p_seas_3, &
                         p_seas_4, p_bc2, p_oc2, p_dust_1, &
                         p_dust_2, p_dust_3, p_dust_4, p_bc1 /)
       ! Fraction of activated aerosols for aer_pointers species, values from
       ! Luo et al. (2020)
-      aq_aer_ratio = (/ 1., 1., 1., 1., 1., 0.5, 0.5, 0., 0., 0., 0., 0. /)
-      ice_aer_ratio = (/ 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 0. /)
+      aq_aer_ratio(:) = (/ 1., 1., 1., 1., 1., 0.5, 0.5, 0., 0., 0., 0., 0. /)
+      ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 0. /)
       ! List of washed out fine aerosol for aer_pointers species (r<=1
       ! micrometer)
-      aer_is_fine = (/ .true., .true., .true., .false., &
+      aer_is_fine(:) = (/ .true., .true., .true., .false., &
                        .false., .true., .true. , .true., &
                        .false., .false., .false., .false. /)
       ! List of washed out coarse aerosol for aer_pointers species (r>1
       ! micrometer)
-      aer_is_coarse = (/ .false., .false., .false., .true., &
+      aer_is_coarse(:) = (/ .false., .false., .false., .true., &
                        .true., .false., .false. , .false., &
                        .true., .true., .true., .false. /)
     ELSE


### PR DESCRIPTION
In chem/module_aer_wetscav_simple.F, the properties of aerosol species scavenged by the scheme were set in the init routine in the aer_pointers,aq_aer_ratio,ice_aer_ratio,aer_is_fine,aer_is_coarse arrays of dimension naerspecies. The init routine initialized naerspecies=12 for GOCART aerosols, but 13 species are declared into the data arrays. This changes naerspecies to 13.