### PR TITLE
Enable wet scavenging with THOMPSON aerosols (issue #34)

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -373,16 +373,28 @@ call wrf_message("**************************************************************
        else
          call wrf_error_fatal("ERROR: wet scavenging option requires chem_opt = 8 through 13 or 31 to 36 or 41 to 42 or 109 or 503 or 504 or 601 or 611 to function.")
        endif
-       if ( config_flags%mp_physics /= 2 .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 11  &
-            .and. config_flags%mp_physics /= 22 .and. config_flags%mp_physics /= THOMPSONAERO &
+       if ( config_flags%mp_physics /= 2 .and. config_flags%mp_physics /= 10 &
+            .and. config_flags%mp_physics /= 11  &
+            .and. config_flags%mp_physics /= 22  &
+            .and. config_flags%mp_physics /= THOMPSONAERO &
+            .and. config_flags%mp_physics /= THOMPSON &
             .and. .not. ( config_flags%mp_physics == 18 .and. config_flags%nssl_2moment_on == 1 ) ) then
-         call wrf_error_fatal("ERROR: wet scavenging option requires mp_phys = 2 (Lin et al.) or 8,28 (Thompson) or 10 (Morrison) or 11 (CAMMGMP) or 18 NSSL_2mom to function.")
+         call wrf_error_fatal("ERROR: wet scavenging option requires &
+                & mp_phys = 2 (Lin et al.) or 8,28 (Thompson) or &
+                & 10 (Morrison) or 11 (CAMMGMP) or 18 (NSSL_2mom) to &
+                & function.")
        endif
      ! MOZART options and domain id = 1
      elseif( id == 1 ) then
-       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= 8 .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
-            .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22 .and. config_flags%mp_physics /= THOMPSONAERO) then
-         call wrf_error_fatal("ERROR: wet scavenging option for MOZART,MOZCART requires mp_phys = 6 (WSM6) or 8,28 (Thompson) or 10 (Morrison) .or 17/18/22 (NSSL 2-moment) to function.")
+       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= 8 &
+            .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
+            .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22 &
+            .and. config_flags%mp_physics /= THOMPSON &
+            .and. config_flags%mp_physics /= THOMPSONAERO) then
+         call wrf_error_fatal("ERROR: wet scavenging option for &
+                & MOZART,MOZCART requires mp_phys = 6 (WSM6) or 8,28 &
+                & (Thompson) or 10 (Morrison) .or 17/18/22 (NSSL 2-moment) &
+                & to function.")
        else
          ! MOZART (trace gas) wet scavenging
          write(message_txt,*) 'chem_init: calling wetscav_mozcart_init for domain ',id

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -386,10 +386,9 @@ call wrf_message("**************************************************************
        endif
      ! MOZART options and domain id = 1
      elseif( id == 1 ) then
-       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= 8 &
+       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= THOMPSON &
             .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
             .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22 &
-            .and. config_flags%mp_physics /= THOMPSON &
             .and. config_flags%mp_physics /= THOMPSONAERO) then
          call wrf_error_fatal("ERROR: wet scavenging option for &
                 & MOZART,MOZCART requires mp_phys = 6 (WSM6) or 8,28 &

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -373,26 +373,29 @@ call wrf_message("**************************************************************
        else
          call wrf_error_fatal("ERROR: wet scavenging option requires chem_opt = 8 through 13 or 31 to 36 or 41 to 42 or 109 or 503 or 504 or 601 or 611 to function.")
        endif
-       if ( config_flags%mp_physics /= 2 .and. config_flags%mp_physics /= 10 &
-            .and. config_flags%mp_physics /= 11  &
-            .and. config_flags%mp_physics /= 22  &
-            .and. config_flags%mp_physics /= THOMPSONAERO &
+       if ( config_flags%mp_physics /= LINSCHEME &
             .and. config_flags%mp_physics /= THOMPSON &
-            .and. .not. ( config_flags%mp_physics == 18 .and. config_flags%nssl_2moment_on == 1 ) ) then
+            .and. config_flags%mp_physics /= THOMPSONAERO &
+            .and. config_flags%mp_physics /= MORR_TWO_MOMENT &
+            .and. config_flags%mp_physics /= CAMMGMPSCHEME  &
+            .and. .not. ( config_flags%mp_physics == NSSL_2MOM &
+                          .and. config_flags%nssl_2moment_on == 1 ) ) then
          call wrf_error_fatal("ERROR: wet scavenging option requires &
-                & mp_phys = 2 (Lin et al.) or 8,28 (Thompson) or &
+                & mp_physics = 2 (Lin et al.) or 8,28 (Thompson) or &
                 & 10 (Morrison) or 11 (CAMMGMP) or 18 (NSSL_2mom) to &
                 & function.")
        endif
      ! MOZART options and domain id = 1
      elseif( id == 1 ) then
-       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= THOMPSON &
-            .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
-            .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22 &
-            .and. config_flags%mp_physics /= THOMPSONAERO) then
+       if ( config_flags%mp_physics /= WSM6SCHEME &
+            .and. config_flags%mp_physics /= THOMPSON &
+            .and. config_flags%mp_physics /= THOMPSONAERO
+            .and. config_flags%mp_physics /= MORR_TWO_MOMENT &
+            .and. .not. ( config_flags%mp_physics == NSSL_2MOM &
+                          .and. config_flags%nssl_2moment_on == 1 ) ) then
          call wrf_error_fatal("ERROR: wet scavenging option for &
-                & MOZART,MOZCART requires mp_phys = 6 (WSM6) or 8,28 &
-                & (Thompson) or 10 (Morrison) .or 17/18/22 (NSSL 2-moment) &
+                & MOZART,MOZCART requires mp_physics = 6 (WSM6) or 8,28 &
+                & (Thompson) or 10 (Morrison) .or 18 (NSSL 2-moment) &
                 & to function.")
        else
          ! MOZART (trace gas) wet scavenging


### PR DESCRIPTION
Adds a condition in chem/chemics_init.F for enabling wet scavenging (wetscav_onoff = 1) with THOMPSON microphysics (mp_physics = 8). It is now possible to use these options together. This also reformats the error messages associated to the mp_physics conditions.