### PR TITLE
Enable wet scavenging of aerosols with THOMPSON microphysics, v4.3.3 (#34)

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -349,12 +349,13 @@ call wrf_message("**************************************************************
          call wrf_error_fatal("ERROR: wet scavenging option requires chem_opt = 8 through 13 or 31 to 36 or 41 to 42 or 109 or 503 or 504 or 601 or 611 to function.")
        endif
        if ( config_flags%mp_physics /= 2 .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 11  &
+            .and. config_flags%mp_physics /= THOMPSON .and. config_flags%mp_physics /= THOMPSONAERO &
             .and. config_flags%mp_physics /= 17 .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22) then
-         call wrf_error_fatal("ERROR: wet scavenging option requires mp_phys = 2 (Lin et al.) or 10 (Morrison) or 11 (CAMMGMP) or 17/18/22 NSSL_2mom to function.")
+         call wrf_error_fatal("ERROR: wet scavenging option requires mp_phys = 2 (Lin et al.) or 8,28 (Thompson) or 10 (Morrison) or 11 (CAMMGMP) or 17/18/22 NSSL_2mom to function.")
        endif
      ! MOZART options and domain id = 1
      elseif( id == 1 ) then
-       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= 8 .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
+       if ( config_flags%mp_physics /= 6 .and. config_flags%mp_physics /= THOMPSON .and. config_flags%mp_physics /= 10 .and. config_flags%mp_physics /= 17  &
             .and. config_flags%mp_physics /= 18 .and. config_flags%mp_physics /= 22 .and. config_flags%mp_physics /= THOMPSONAERO) then
          call wrf_error_fatal("ERROR: wet scavenging option for MOZART,MOZCART requires mp_phys = 6 (WSM6) or 8,28 (Thompson) or 10 (Morrison) .or 17/18/22 (NSSL 2-moment) to function.")
        else


### PR DESCRIPTION
Adds a condition in chem/chemics_init.F for enabling wet scavenging (wetscav_onoff = 1) with THOMPSON microphysics (mp_physics = 8). It is now possible to use these options together.