### PR TITLE
Fix numerical errors caught by the debug compile options (#51)

### DIFF
--- a/chem/module_gocart_chem.F
+++ b/chem/module_gocart_chem.F
@@ -121,7 +121,7 @@ CONTAINS
               ! fnight/=0.0 (for fnight=0: all cosszax (including current
               ! cossza) > 0.0)
               IF(fnight > 0.) THEN
-                xno3(1,1,1) = backg_no3(i,k,j) / (1.0 - TTDAY(i,j)/86400.)
+                xno3(1,1,1) = backg_no3(i,k,j) / fnight
               ELSE
                 xno3(1,1,1) = 0.0
               ENDIF

--- a/chem/module_gocart_chem.F
+++ b/chem/module_gocart_chem.F
@@ -44,6 +44,7 @@ CONTAINS
   real, DIMENSION (1,1) :: sza,cosszax
   real*8, DIMENSION (1,1,1,4) :: tc,bems
   real*8, dimension (1) :: dxy
+  REAL(kind=8) :: fnight
   real(kind=8) :: xtime,xhour
   real:: rlat,xlonn
   real :: zenith,zenita,azimuth,xmin,xtimin,gmtp
@@ -113,13 +114,17 @@ CONTAINS
               XNO3(1,1,1) = 0.0
            ELSE
               ! -- Fraction of night
-              ! fnight       = 1.0 - TTDAY(i,j)/86400.0
+              fnight = 1.0 - TTDAY(i,j)/86400.0
               ! The original xno3 values have been averaged over daytime
               ! as well => divide by fnight to get the appropriate night-time
               ! fraction from the monthly average
               ! fnight/=0.0 (for fnight=0: all cosszax (including current
               ! cossza) > 0.0)
-              xno3(1,1,1) = backg_no3(i,k,j) / (1.0 - TTDAY(i,j)/86400.)
+              IF(fnight > 0.) THEN
+                xno3(1,1,1) = backg_no3(i,k,j) / (1.0 - TTDAY(i,j)/86400.)
+              ELSE
+                xno3(1,1,1) = 0.0
+              ENDIF
            END IF
 !         if(i.eq.19.and.j.eq.19.and.k.eq.kts)then
 !          write(0,*)backg_oh(i,k,j),backg_no3(i,k,j),ttday(i,j),tcosz(i,j)

--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -727,19 +727,19 @@ CONTAINS
 
        DO i=ITS,ITF
           if (FLAG_QI ) then
-             sqi(:)=sqi3D(i,:)
+             sqi(kts:kte)=sqi3D(i,kts:kte)
           else
              sqi = 0.0
           endif
           if (FLAG_QS ) then
-             sqs(:)=sqs3D(i,:)
+             sqs(kts:kte)=sqs3D(i,kts:kte)
           else
              sqs = 0.0
           endif
           if (icloud_bl > 0) then
-             cldfra_bl1d(:)=cldfra_bl(i,:)
-             qc_bl1d(:)=qc_bl(i,:)
-             qi_bl1d(:)=qi_bl(i,:)
+             cldfra_bl1d(kts:kte)=cldfra_bl(i,kts:kte)
+             qc_bl1d(kts:kte)=qc_bl(i,kts:kte)
+             qi_bl1d(kts:kte)=qi_bl(i,kts:kte)
           endif
 
           do k=KTS,KTE !KTF
@@ -866,25 +866,25 @@ CONTAINS
     DO i=ITS,ITF
        !Initialize some arrays
        if (tke_budget .eq. 1) then
-          dqke(i,:)=qke(i,:)
+          dqke(i,kts:kte)=qke(i,kts:kte)
        endif
        if (FLAG_QI ) then
-          sqi(:)=sqi3D(i,:)
+          sqi(kts:kte)=sqi3D(i,kts:kte)
        else
           sqi = 0.0
        endif
        if (FLAG_QS ) then
-          sqs(:)=sqs3D(i,:)
+          sqs(kts:kte)=sqs3D(i,kts:kte)
        else
           sqs = 0.0
        endif
        if (icloud_bl > 0) then
-          CLDFRA_BL1D(:)=CLDFRA_BL(i,:)
-          QC_BL1D(:)   =QC_BL(i,:)
-          QI_BL1D(:)   =QI_BL(i,:)
-          cldfra_bl1D_old(:)=cldfra_bl(i,:)
-          qc_bl1D_old(:)=qc_bl(i,:)
-          qi_bl1D_old(:)=qi_bl(i,:)
+          CLDFRA_BL1D(kts:kte)=CLDFRA_BL(i,kts:kte)
+          QC_BL1D(kts:kte)   =QC_BL(i,kts:kte)
+          QI_BL1D(kts:kte)   =QI_BL(i,kts:kte)
+          cldfra_bl1D_old(kts:kte)=cldfra_bl(i,kts:kte)
+          qc_bl1D_old(kts:kte)=qc_bl(i,kts:kte)
+          qi_bl1D_old(kts:kte)=qi_bl(i,kts:kte)
        else
           CLDFRA_BL1D  =0.0
           QC_BL1D      =0.0

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -2628,25 +2628,48 @@
 !.. results in lookup table.
           if (rg(k).ge. r_g(1)) then
            if (twet(k).lt.T_0) then
-            prg_rcg(k) = tmr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &
-                         + tcr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            if(is_hail_aware) then
+              prg_rcg(k) = tmr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &
+                           + tcr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            else
+              prg_rcg(k) = tmr_racg(idx_g1,idx_g,1,idx_r1,idx_r)  &
+                           + tcr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
+            endif
             prg_rcg(k) = MIN(DBLE(rr(k)*odts), prg_rcg(k))
             prr_rcg(k) = -prg_rcg(k)
-            pnr_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &   ! RAIN2M
-                         + tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            if(is_hail_aware) then
+              pnr_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &   ! RAIN2M
+                           + tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            else
+              pnr_rcg(k) = tnr_racg(idx_g1,idx_g,1,idx_r1,idx_r)  &   ! RAIN2M
+                           + tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
+            endif
             pnr_rcg(k) = MIN(DBLE(nr(k)*odts), pnr_rcg(k))
 !-GT        pbg_rcg(k) = prg_rcg(k)/(0.5*(rho_i+rho_g(idx_bg(k))))
             pbg_rcg(k) = prg_rcg(k)/rho_i
            else
-            prr_rcg(k) = tcg_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            if(is_hail_aware) then
+              prr_rcg(k) = tcg_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            else
+              prr_rcg(k) = tcg_racg(idx_g1,idx_g,1,idx_r1,idx_r)
+            endif
             prr_rcg(k) = MIN(DBLE(rg(k)*odts), prr_rcg(k))
             prg_rcg(k) = -prr_rcg(k)
-            png_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            if(is_hail_aware) then
+              png_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
 !!!                    + tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
+            else
+              png_rcg(k) = tnr_racg(idx_g1,idx_g,1,idx_r1,idx_r)
+!!!                    + tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
+            endif
             png_rcg(k) = MIN(DBLE(ng(k)*odts), png_rcg(k))
             pbg_rcg(k) = prg_rcg(k)/rho_g(idx_bg(k))
 !..Put in explicit drop break-up due to collisions.
-            pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  ! RAIN2M
+            if(is_hail_aware) then
+              pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  ! RAIN2M
+            else
+              pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)  ! RAIN2M
+            endif
            endif
           endif
          endif

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1691,7 +1691,7 @@
       INTEGER, DIMENSION(5):: ksed1
       INTEGER:: nir, nis, nig, nii, nic, niin
       INTEGER:: idx_tc, idx_t, idx_s, idx_g1, idx_g, idx_r1, idx_r,     &
-                idx_i1, idx_i, idx_c, idx, idx_d, idx_n, idx_in
+                idx_i1, idx_i, idx_c, idx, idx_d, idx_n, idx_in, idx_rhg
       INTEGER, DIMENSION(kts:kte):: idx_bg
 
       LOGICAL:: melti, no_micro
@@ -2483,6 +2483,11 @@
           idx_g = 1
           idx_g1 = ntb_g1
          endif
+         if(is_hail_aware) then
+           idx_rhg = idx_bg(k)
+         else
+           idx_rhg = 1
+         endif
 
 !..Deposition/sublimation prefactor (from Srivastava & Coen 1992).
          otemp = 1./temp(k)
@@ -2628,48 +2633,25 @@
 !.. results in lookup table.
           if (rg(k).ge. r_g(1)) then
            if (twet(k).lt.T_0) then
-            if(is_hail_aware) then
-              prg_rcg(k) = tmr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &
-                           + tcr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
-            else
-              prg_rcg(k) = tmr_racg(idx_g1,idx_g,1,idx_r1,idx_r)  &
-                           + tcr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
-            endif
+            prg_rcg(k) = tmr_racg(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)  &
+                         + tcr_gacr(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)
             prg_rcg(k) = MIN(DBLE(rr(k)*odts), prg_rcg(k))
             prr_rcg(k) = -prg_rcg(k)
-            if(is_hail_aware) then
-              pnr_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  &   ! RAIN2M
-                           + tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
-            else
-              pnr_rcg(k) = tnr_racg(idx_g1,idx_g,1,idx_r1,idx_r)  &   ! RAIN2M
-                           + tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
-            endif
+            pnr_rcg(k) = tnr_racg(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)  &   ! RAIN2M
+                         + tnr_gacr(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)
             pnr_rcg(k) = MIN(DBLE(nr(k)*odts), pnr_rcg(k))
-!-GT        pbg_rcg(k) = prg_rcg(k)/(0.5*(rho_i+rho_g(idx_bg(k))))
+!-GT        pbg_rcg(k) = prg_rcg(k)/(0.5*(rho_i+rho_g(idx_rhg)))
             pbg_rcg(k) = prg_rcg(k)/rho_i
            else
-            if(is_hail_aware) then
-              prr_rcg(k) = tcg_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
-            else
-              prr_rcg(k) = tcg_racg(idx_g1,idx_g,1,idx_r1,idx_r)
-            endif
+            prr_rcg(k) = tcg_racg(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)
             prr_rcg(k) = MIN(DBLE(rg(k)*odts), prr_rcg(k))
             prg_rcg(k) = -prr_rcg(k)
-            if(is_hail_aware) then
-              png_rcg(k) = tnr_racg(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
-!!!                    + tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)
-            else
-              png_rcg(k) = tnr_racg(idx_g1,idx_g,1,idx_r1,idx_r)
-!!!                    + tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)
-            endif
+            png_rcg(k) = tnr_racg(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)
+!!!                    + tnr_gacr(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)
             png_rcg(k) = MIN(DBLE(ng(k)*odts), png_rcg(k))
-            pbg_rcg(k) = prg_rcg(k)/rho_g(idx_bg(k))
+            pbg_rcg(k) = prg_rcg(k)/rho_g(idx_rhg)
 !..Put in explicit drop break-up due to collisions.
-            if(is_hail_aware) then
-              pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,idx_bg(k),idx_r1,idx_r)  ! RAIN2M
-            else
-              pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,1,idx_r1,idx_r)  ! RAIN2M
-            endif
+            pnr_rcg(k) = -1.5*tnr_gacr(idx_g1,idx_g,idx_rhg,idx_r1,idx_r)  ! RAIN2M
            endif
           endif
          endif


### PR DESCRIPTION
This fixes several numerical errors identified by running the model with the debug compile options, specifically.
1- A divide by zero error in module_gocart_chem.F
2- A size mismatch assignment error in module_bl_mynn.F
3- An out of bounds error in module_mp_thompson.F