### PR TITLE
Make C-code more compliant with C23 standard, into v4.3.3

### DIFF
--- a/external/RSL_LITE/rsl_bcast.c
+++ b/external/RSL_LITE/rsl_bcast.c
@@ -728,7 +728,7 @@ rsl_lite_from_peerpoint_msg ( len_p, buf )
 
 destroy_list( list, dfcn )
   rsl_list_t ** list ;          /* pointer to pointer to list */
-  int (*dfcn)() ;               /* pointer to function for destroying
+  int (*dfcn)(void *) ;         /* pointer to function for destroying
                                    the data field of the list */
 {
   rsl_list_t *p, *trash ;

--- a/external/io_grib1/MEL_grib1/pack_spatial.c
+++ b/external/io_grib1/MEL_grib1/pack_spatial.c
@@ -88,7 +88,7 @@ int	pack_spatial (  pt_cnt, bit_cnt, pack_null, fbuff, ppbitstream,
     float max_grid;		/* maximum value in grid */
     float ftemp;		/* temporary float containing grid value */
     unsigned long *pBitstream;
-    unsigned long grib_local_ibm();
+    unsigned long grib_local_ibm(double);
     int wordnum;
     int zero_cnt;
     int prec_too_high = 0;


### PR DESCRIPTION
This fixes issue #56 for WRF-Chem-Polar v4.3.3.