### PR TITLE
Fix aqueous chemistry initialization (#59)

### DIFF
--- a/chem/module_cmu_bulkaqchem.F
+++ b/chem/module_cmu_bulkaqchem.F
@@ -576,7 +576,9 @@
       enddo
       lrw = lrw1                      ! dimension of double precision work vector
       liw = liw1                      ! dimension of integer work vector
+      iwork(5) = 5                    ! maximum order, 5 for method = 2 (mf > 20)
       iwork(6) = worki                ! steps allowed
+      iwork(7) = 10                   ! max nb of messages
       rwork(6) = workr                ! maximum step in seconds
 
 !

--- a/chem/module_cmu_bulkaqchem.F
+++ b/chem/module_cmu_bulkaqchem.F
@@ -576,9 +576,11 @@
       enddo
       lrw = lrw1                      ! dimension of double precision work vector
       liw = liw1                      ! dimension of integer work vector
-      iwork(5) = 5                    ! maximum order, 5 for method = 2 (mf > 20)
+      iwork(1) = -1 ! make sure this value is not used
+      iwork(2) = -1 ! make sure this value is not used
+      iwork(5) = 0  ! use default value
       iwork(6) = worki                ! steps allowed
-      iwork(7) = 10                   ! max nb of messages
+      iwork(7) = 0. ! use default value
       rwork(6) = workr                ! maximum step in seconds
 
 !


### PR DESCRIPTION
In chem/module_cmu_bulkaqchem.F, add initializations for iwork(5) and iwork(7), used to set option flags maxord and mxhnil in chem/module_cmu_dvode_solver.F

If this is not done and the corresponding empty values are negative, aqueous chemistry is never performed.