### PR TITLE
Fix syntax error in chem/module_cmu_bulkaqchem.F (#59)

### DIFF
--- a/chem/module_cmu_bulkaqchem.F
+++ b/chem/module_cmu_bulkaqchem.F
@@ -576,11 +576,11 @@
       enddo
       lrw = lrw1                      ! dimension of double precision work vector
       liw = liw1                      ! dimension of integer work vector
-      iwork(1) = -1 ! make sure this value is not used
-      iwork(2) = -1 ! make sure this value is not used
-      iwork(5) = 0  ! use default value
+      iwork(1) = -1                   ! make sure this value is not used
+      iwork(2) = -1                   ! make sure this value is not used
+      iwork(5) = 0                    ! use default value
       iwork(6) = worki                ! steps allowed
-      iwork(7) = 0. ! use default value
+      iwork(7) = 0                    ! use default value
       rwork(6) = workr                ! maximum step in seconds
 
 !


### PR DESCRIPTION
I fixed `iwork(7) = 0.` into `iwork(7) = 0`. Since `iwork` is an array of integers, I am not sure any or all compilers will accept `0.` as a value.

