### PR TITLE
Add dust and sea salt aerosol deposition output (#67)

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -1149,6 +1149,8 @@ state    real  ddmass_co3_cw01      i%jf      dvel          1         -      rdu
 state    real  ddmass_co3_cw02      i%jf      dvel          1         -      rdu    "ddmass_co3_cw02"    "co3_cw02 dry deposition, accumulated"  "ug/m2"
 state    real  ddmass_co3_cw03      i%jf      dvel          1         -      rdu    "ddmass_co3_cw03"    "co3_cw03 dry deposition, accumulated"  "ug/m2"
 state    real  ddmass_co3_cw04      i%jf      dvel          1         -      rdu    "ddmass_co3_cw04"    "co3_cw04 dry deposition, accumulated"  "ug/m2"
+state    real  dd_dust      ij      misc          1         -      rhdu    "dd_dust"    "Mineral dust dry deposition, accumulated"  "kg/m2"
+state    real  dd_seasalt   ij      misc          1         -      rhdu    "dd_seasalt" "Sea salt dry deposition, accumulated"  "kg/m2"
 
 # aerosol surface area diagnostic
 state  real  -                ikjf    aero_srf_area   1    -   -     - 
@@ -1163,6 +1165,8 @@ state   integer num_vert_mix     -     misc           -         -      r      "n
 #
 # Wet deposition
 #
+state    real  wd_dust_sc     ij        misc           1         -      rhdu      "wd_dust_sc"     "Mineral dust surface wet deposition, accumulated (Sc)"            "kg/m2"
+state    real  wd_seasalt_sc     ij        misc           1         -      rhdu      "wd_seasalt_sc"     "Sea-salt surface wet deposition, accumulated (Sc)"            "kg/m2"
 state    real  wd_so4_sc     ij        misc           1         -      rdu      "wd_so4_sc"     "SO4 surface wet deposition, accumulated (Sc)"            "mmol/m2"
 state    real  wd_no3_sc     ij        misc           1         -      rdu      "wd_no3_sc"     "NO3 surface wet deposition, accumulated (Sc)"            "mmol/m2"
 # added wet deposition totals for NH4 and OA for MOZART coupled version

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -1101,6 +1101,7 @@
                  grid%xice,                                                           &
                  grid%dustdrydep_1,grid%dustdrydep_2,grid%dustdrydep_3,               &
                  grid%dustdrydep_4,grid%dustdrydep_5,                                 &      
+                 grid%dd_dust, grid%dd_seasalt,                                       &
                  grid%depvelocity,                                                    &      
                  grid%dustgraset_1,grid%dustgraset_2,grid%dustgraset_3,               &
                  grid%dustgraset_4,grid%dustgraset_5,                                 &
@@ -1668,6 +1669,7 @@ if ( cam_mam_aerosols ) &
               grid%wd_no3_sc, grid%wd_so4_sc, grid%wd_nh4_sc,grid%wd_oa_sc,           &
               grid%wd_so2_sc, grid%wd_sulf_sc, grid%wd_hno3_sc, grid%wd_nh3_sc,       &
               grid%wd_cvasoa_sc, grid%wd_cvbsoa_sc, grid%wd_asoa_sc, grid%wd_bsoa_sc, &
+              grid%wd_dust_sc, grid%wd_seasalt_sc,                                    &
               grid%qv_b4mp, grid%qc_b4mp, grid%qi_b4mp, grid%qs_b4mp,                 &
 !======================================================================================
 !Variables required for CAM_MAM_WETSCAV

--- a/chem/dry_dep_driver.F
+++ b/chem/dry_dep_driver.F
@@ -25,6 +25,7 @@ CONTAINS
                sf_urban_physics,numgas,current_month,dvel,snowh,xice,     &
                dustdrydep_1,dustdrydep_2,dustdrydep_3,                    &
                dustdrydep_4,dustdrydep_5,                                 &
+               dd_dust, dd_seasalt,                                       &
                depvelocity,                                               &
                dustgraset_1,dustgraset_2,dustgraset_3,                    &
                dustgraset_4,dustgraset_5,                                 &
@@ -161,6 +162,8 @@ CONTAINS
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::        &
                 dustdrydep_1, dustdrydep_2, dustdrydep_3,       &
                 dustdrydep_4, dustdrydep_5, depvelocity
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::        &
+                dd_dust, dd_seasalt
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::        &
                dustgraset_1,dustgraset_2,dustgraset_3,          &
                dustgraset_4,dustgraset_5,                       &
@@ -853,6 +856,62 @@ CONTAINS
         ENDDO ! isize
       ENDIF !THOMPSONAERO and aci_wrfchem_opt and MOSAIC
 
+      ! Add total dust and seasalt deposition output
+      ! This is for the case where dry deposition is calculated in vertmx, if
+      ! it is calculated in mixactivate see the case further down
+      if(config_flags%aci_wrfchem_opt /= 0 .and. &
+         (config_flags%chem_opt == CBMZ_MOSAIC_DMS_4BIN_AQ .or. &
+          config_flags%chem_opt == MOZART_MOSAIC_4BIN_AQ_KPP .or. &
+          config_flags%chem_opt == CRI_MOSAIC_4BIN_AQ_KPP)) then
+        dd_dust(i,j) = dd_dust(i,j) &
+                  + 1.E-9 * ( &
+                  + ddmassn(p_oin_a01) &
+                  + ddmassn(p_oin_a02) &
+                  + ddmassn(p_oin_a03) &
+                  + ddmassn(p_oin_a04) &
+                  + ddmassn(p_oin_cw01) &
+                  + ddmassn(p_oin_cw02) &
+                  + ddmassn(p_oin_cw03) &
+                  + ddmassn(p_oin_cw04))
+        dd_seasalt(i,j) = dd_seasalt(i,j) &
+                  + 1.E-9 * ( &
+                  + ddmassn(p_na_a01) &
+                  + ddmassn(p_na_a02) &
+                  + ddmassn(p_na_a03) &
+                  + ddmassn(p_na_a04) &
+                  + ddmassn(p_na_cw01) &
+                  + ddmassn(p_na_cw02) &
+                  + ddmassn(p_na_cw03) &
+                  + ddmassn(p_na_cw04) &
+                  + ddmassn(p_cl_a01) &
+                  + ddmassn(p_cl_a02) &
+                  + ddmassn(p_cl_a03) &
+                  + ddmassn(p_cl_a04) &
+                  + ddmassn(p_cl_cw01) &
+                  + ddmassn(p_cl_cw02) &
+                  + ddmassn(p_cl_cw03) &
+                  + ddmassn(p_cl_cw04))
+      elseif(config_flags%chem_opt == MOZCART_KPP .or. &
+             config_flags%chem_opt == T1_MOZCART_KPP .or. &
+             config_flags%chem_opt == GOCART_SIMPLE .or. &
+             config_flags%chem_opt == GOCARTRACM_KPP .or. &
+             config_flags%chem_opt == GOCARTRADM2) then
+        dd_dust(i,j) = dd_dust(i,j) &
+                  + 1.E-9 * ( &
+                  + ddmassn(p_dust_1) &
+                  + ddmassn(p_dust_2) &
+                  + ddmassn(p_dust_3) &
+                  + ddmassn(p_dust_4) &
+                  + ddmassn(p_dust_4) &
+                  + ddmassn(p_dust_5))
+        dd_seasalt(i,j) = dd_seasalt(i,j) &
+                  + 1.E-9 * ( &
+                  + ddmassn(p_seas_1) &
+                  + ddmassn(p_seas_2) &
+                  + ddmassn(p_seas_3) &
+                  + ddmassn(p_seas_4))
+      endif
+
       if( config_flags%diagnostic_chem == DEPVEL1 .and. &
           (config_flags%chem_opt == CB05_SORG_VBS_AQ_KPP) ) then
         dvel(i,1,j,p_ddmass_o3) = dvel(i,1,j,p_ddmass_o3) + ddmassn(p_o3)
@@ -1180,6 +1239,42 @@ CONTAINS
           ims,ime, jms,jme, kms,kme,                        &
           its,ite, jts,jte, kts,kte                         )
       ENDIF
+
+      ! Add total dust and seasalt deposition output
+      ! This case is for when dry deposition is calculated in mixactivate
+      if(config_flags%aci_wrfchem_opt == 0 .and. &
+            (config_flags%chem_opt == CBMZ_MOSAIC_4BIN_AQ .or. &
+             config_flags%chem_opt == CBMZ_MOSAIC_DMS_4BIN_AQ .or. &
+             config_flags%chem_opt == MOZART_MOSAIC_4BIN_AQ_KPP)) then
+        dd_dust(ims:ime,jms:jme) = dd_dust(ims:ime,jms:jme) &
+                  - dtstep * ( &
+                  qsrflx(ims:ime,jms:jme,p_oin_a01) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_a02) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_a03) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_a04) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_cw01) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_cw02) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_cw03) &
+                  + qsrflx(ims:ime,jms:jme,p_oin_cw04))
+        dd_seasalt(ims:ime,jms:jme) = dd_seasalt(ims:ime,jms:jme) &
+                  - dtstep * ( &
+                  + qsrflx(ims:ime,jms:jme,p_na_a01) &
+                  + qsrflx(ims:ime,jms:jme,p_na_a02) &
+                  + qsrflx(ims:ime,jms:jme,p_na_a03) &
+                  + qsrflx(ims:ime,jms:jme,p_na_a04) &
+                  + qsrflx(ims:ime,jms:jme,p_na_cw01) &
+                  + qsrflx(ims:ime,jms:jme,p_na_cw02) &
+                  + qsrflx(ims:ime,jms:jme,p_na_cw03) &
+                  + qsrflx(ims:ime,jms:jme,p_na_cw04) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_a01) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_a02) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_a03) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_a04) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_cw01) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_cw02) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_cw03) &
+                  + qsrflx(ims:ime,jms:jme,p_cl_cw04))
+      endif
 
       if( config_flags%diagnostic_chem == DEPVEL1 .and. &
           config_flags%chem_opt == CB05_SORG_VBS_AQ_KPP ) then

--- a/chem/dry_dep_driver.F
+++ b/chem/dry_dep_driver.F
@@ -902,7 +902,6 @@ CONTAINS
                   + ddmassn(p_dust_2) &
                   + ddmassn(p_dust_3) &
                   + ddmassn(p_dust_4) &
-                  + ddmassn(p_dust_4) &
                   + ddmassn(p_dust_5))
         dd_seasalt(i,j) = dd_seasalt(i,j) &
                   + 1.E-9 * ( &

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -57,7 +57,7 @@ CONTAINS
 !----------------------------------------------------------------------------
 
    SUBROUTINE aer_wetscav_simple( id, dtstep, config_flags,                &
-                              t_phy, p_phy, dz8w,                          &
+                              t_phy, p_phy, dz8w, qsrflx,                  &
                               chem, rho_phy, cldfra, rainprod, evapprod,   &
                               precr, preci, precs, precg, dx, dy,          &
                               qv, qc, qi, qs, qr, qg,                      &
@@ -94,6 +94,8 @@ CONTAINS
    !   ids,ims,its etc. = domain, memory, and tile start and end indices
    ! Input/output:
    !   chem = advected chemical species (gases in ppm, aerosols in ug/kg)
+   ! Output:
+   !   qsrflx = aerosol column change due to scavenging (µg/m2)
 
    ! USE associations:
    !TODO Use ONLY:
@@ -126,6 +128,8 @@ CONTAINS
        INTENT(IN) :: cldfra
    REAL, DIMENSION(ims:ime, kms:kme, jms:jme, num_chem),          &
        INTENT(INOUT) :: chem
+   REAL, DIMENSION(ims:ime, jms:jme, num_chem),          &
+         INTENT(OUT) :: qsrflx
 
    !---- Local variables and parameters
    ! x,y,z, and chemical species index, chemical species pointer
@@ -301,6 +305,16 @@ CONTAINS
 
          END DO ! nv
        END DO ! k
+
+       !---- Output deposition fluxes
+       DO nv = 1,naerspecies
+         p_chem = aer_pointers(nv)
+         IF(p_chem > param_first_scalar) THEN
+           ! WRF-Chem convention is negative from atmosphere to the ground
+           qsrflx(i,j,p_chem) = -deposition_flux(nv)
+         ENDIF
+       END DO ! nv
+
      END DO ! i
    END DO ! j
 

--- a/chem/module_wetscav_driver.F
+++ b/chem/module_wetscav_driver.F
@@ -412,7 +412,7 @@ REAL,  DIMENSION( ims:ime , kms:kme , jms:jme , ntot_amode ),       &
        IF(config_flags%chem_opt == MOZCART_KPP .OR. config_flags%chem_opt == T1_MOZCART_KPP) THEN
          CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
          CALL aer_wetscav_simple( id, dtstep, config_flags,                     &
-                                  t_phy, p_phy, dz8w,                           &
+                                  t_phy, p_phy, dz8w, qsrflx,                   &
                                   chem, rho_phy, cldfra_ls, rainrate, evaprate, &
                                   precr, preci, precs, precg, dx, dy,           &
                                   moist(ims:ime,kms:kme,jms:jme,p_qv),          &
@@ -509,7 +509,7 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
      endif
      CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
      CALL aer_wetscav_simple( id, dtstep, config_flags,                     &
-                              t_phy, p_phy, dz8w,                           &
+                              t_phy, p_phy, dz8w, qsrflx,                   &
                               chem, rho_phy, cldfra_ls, rainrate, evaprate, &
                               precr, preci, precs, precg, dx, dy,           &
                               moist(ims:ime,kms:kme,jms:jme,p_qv),          &
@@ -529,7 +529,29 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
    ! column change. It is assumed that all precipitation reaches the ground.
    
     SELECT CASE(config_flags%chem_opt)
+
+      CASE( GOCART_SIMPLE,GOCARTRADM2,GOCARTRACM_KPP,MOZCART_KPP,T1_MOZCART_KPP )
       
+      do jj=jts,jte
+        do ii=its,ite
+          ! Mineral dust wet deposition over the current time step:
+          wdi_dust(ii,jj) = - 1.E-9*qsrflx(ii,jj,p_dust_1) &
+                            - 1.E-9*qsrflx(ii,jj,p_dust_2) &
+                            - 1.E-9*qsrflx(ii,jj,p_dust_3) &
+                            - 1.E-9*qsrflx(ii,jj,p_dust_4) &
+                            - 1.E-9*qsrflx(ii,jj,p_dust_5)
+          ! Accumulated mineral dust wet deposition:
+          wd_dust(ii,jj) = wd_dust(ii,jj) + wdi_dust(ii,jj)         ! kg/m2
+          ! Sea salt wet deposition over the current time step:
+          wdi_seasalt(ii,jj) = - 1.E-9*qsrflx(ii,jj,p_seas_1) &
+                               - 1.E-9*qsrflx(ii,jj,p_seas_2) &
+                               - 1.E-9*qsrflx(ii,jj,p_seas_3) &
+                               - 1.E-9*qsrflx(ii,jj,p_seas_4)
+          ! Accumulated sea salt wet deposition:
+          wd_seasalt(ii,jj) = wd_seasalt(ii,jj) + wdi_seasalt(ii,jj)         ! kg/m2
+        enddo
+      enddo
+
       CASE ( RADM2SORG_AQCHEM,RACMSORG_AQCHEM_KPP,RACM_ESRLSORG_AQCHEM_KPP )
       
       do jj=jts,jte

--- a/chem/module_wetscav_driver.F
+++ b/chem/module_wetscav_driver.F
@@ -29,6 +29,7 @@ CONTAINS
                wd_no3,wd_so4,wd_nh4,wd_oa,                                 &
                wd_so2, wd_sulf, wd_hno3, wd_nh3,                           &
                wd_cvasoa, wd_cvbsoa, wd_asoa, wd_bsoa,                     &
+               wd_dust, wd_seasalt,                                        &
                qv_b4mp, qc_b4mp, qi_b4mp, qs_b4mp,                         &
 !======================================================================================
 !Variables required for CAM_MAM_WETSCAV
@@ -219,7 +220,8 @@ CONTAINS
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT) :: wd_no3,wd_so4, &
                                                           wd_nh4, wd_oa, &
                                                           wd_so2, wd_sulf, &
-                                                          wd_hno3, wd_nh3
+                                                          wd_hno3, wd_nh3, &
+                                                          wd_dust, wd_seasalt
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT) :: &
                    wd_cvasoa, wd_cvbsoa, wd_asoa, wd_bsoa
 !
@@ -279,7 +281,8 @@ REAL,  DIMENSION( ims:ime , kms:kme , jms:jme , ntot_amode ),       &
 ! Wet deposition over the current time step
 !
   REAL, DIMENSION( ims:ime , jms:jme ) :: wdi_no3,wdi_so4,wdi_nh4,wdi_oa, &
-                                          wdi_so2, wdi_sulf, wdi_hno3, wdi_nh3
+                                          wdi_so2, wdi_sulf, wdi_hno3, wdi_nh3, &
+                                          wdi_dust, wdi_seasalt
   REAL, DIMENSION( ims:ime , jms:jme ) :: wdi_cvasoa,wdi_cvbsoa,wdi_asoa,wdi_bsoa
 
 !-----------------------------------------------------------------
@@ -555,6 +558,37 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
 
       do jj=jts,jte
         do ii=its,ite
+          ! Mineral dust wet deposition over the current time step:
+          wdi_dust(ii,jj) = - 1.E-9*qsrflx(ii,jj,p_oin_cw01) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_cw02) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_cw03) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_cw04) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_a01) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_a02) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_a03) &
+                            - 1.E-9*qsrflx(ii,jj,p_oin_a04) ! kg/m2
+          ! Accumulated mineral dust wet deposition:
+          wd_dust(ii,jj) = wd_dust(ii,jj) + wdi_dust(ii,jj)         ! kg/m2
+
+          ! Sea salt wet deposition over the current time step:
+          wdi_seasalt(ii,jj) = - 1.E-9*qsrflx(ii,jj,p_na_cw01) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_cw02) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_cw03) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_cw04) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_a01) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_a02) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_a03) &
+                               - 1.E-9*qsrflx(ii,jj,p_na_a04) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_cw01) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_cw02) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_cw03) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_cw04) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_a01) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_a02) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_a03) &
+                               - 1.E-9*qsrflx(ii,jj,p_cl_a04) ! kg/m2
+          ! Accumulated sea salt wet deposition:
+          wd_seasalt(ii,jj) = wd_seasalt(ii,jj) + wdi_seasalt(ii,jj)         ! kg/m2
 
           ! Nitrate wet deposition over the current time step:
           wdi_no3(ii,jj) = - 0.001*qsrflx(ii,jj,p_no3_cw01)/mw_no3_aer &


### PR DESCRIPTION
Adds wet and dry deposition flux output for mineral dust and sea salt, for MOSAIC-4bin and GOCART aerosols. The output is in wd_dust_sc, wd_seasalt_sc, dd_dust, dd_seasalt.

This fixes issue #67 