### PR TITLE
Refactor simple wet scavenging code

### DIFF
--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -1,10 +1,10 @@
-! 2025/05 Louis Marelle
+! 2025/11 Louis Marelle
 !
 ! Purpose:
-! Perform wet scavenging of aerosols by grid scale rainout/washout
+! - Perform wet scavenging of aerosols by grid scale rainout/washout
 !
 ! Remarks:
-! Washout and rainout from Luo et al. (2019, 2020)
+! - Washout and rainout from Luo et al. (2019, 2020)
 !
 ! References:
 ! ==============================================================================
@@ -16,505 +16,668 @@
 !     processes dramatically improves GEOS-Chem 12.0.0 simulations of surface
 !     nitric acid, nitrate, and ammonium over the United States, Geosci. Model
 !     Dev., 12, 3439–3447, https://doi.org/10.5194/gmd-12-3439-2019, 2019.
-!
-!TODO get wet removal fluxes out for validation
-!TODO use reasonable thresholds instead of 0.0 in all the module
-!TODO remove unused arguments, e.g. dx, dy, config_flags, rho_phy, p_phy
-!TODO maybe use double precision
-!TODO qc,qi,qr,qs,qg should use b4mp arrays
-!
+
 
 MODULE module_aer_wetscav_simple
 
-   ! USE module_wrf_error, ONLY : wrf_debug
+  IMPLICIT NONE
+  PRIVATE
 
-   IMPLICIT NONE
-   PRIVATE
+  PUBLIC :: aer_wetscav_simple, aer_wetscav_simple_init
 
-   PUBLIC :: aer_wetscav_simple, aer_wetscav_simple_init
+  !---- Global module-wide variables
+  !-- Allocatable aerosol arrays
+  ! Dim is number of aerosol species and depends on aerosol mechanism.
+  ! These are initialized in aer_wetscav_simple_init
+  ! Number of wet-scavenged aerosol species for chem_opt (dim of
+  ! aer_pointers)
+  INTEGER :: n_aer
+  ! List of aerosol species experiencing rainout/washout
+  INTEGER, DIMENSION(:), ALLOCATABLE :: aer_pointers
+  ! Rainout activation efficiency of species (0-1)
+  REAL, DIMENSION(:), ALLOCATABLE :: aq_aer_ratio, ice_aer_ratio
+  ! Aerosol diameter (µm) for each species in aer_pointers
+  REAL, DIMENSION(:), ALLOCATABLE :: aer_dry_diam
+  ! Deposition flux of species during timestep (ug/m2)
+  REAL, DIMENSION(:), ALLOCATABLE :: deposition_flux
 
-   !---- Global module-wide variables
-   !-- Allocatable aerosol arrays
-   ! Dim is number of aerosol species and depends on aerosol mechanism.
-   ! These are initialized in aer_wetscav_simple_init
-   REAL, DIMENSION(:), ALLOCATABLE :: mech_aerosol_pointers
-   ! Number of wet-scavenged aerosol species for chem_opt (dim of
-   ! aer_pointers)
-   INTEGER :: naerspecies
-   ! List of aerosol species experiencing rainout/washout
-   INTEGER, DIMENSION(:), ALLOCATABLE :: aer_pointers
-   ! Rainout activation efficiency of species (0-1)
-   REAL, DIMENSION(:), ALLOCATABLE :: aq_aer_ratio, ice_aer_ratio
-   ! Deposition flux of species during timestep (ug/m2)
-   REAL, DIMENSION(:), ALLOCATABLE :: deposition_flux
-   ! List of fine aerosol species in mechanism for washout (r<=1 micrometer)
-   LOGICAL, DIMENSION(:), ALLOCATABLE :: aer_is_fine
-   ! List of coarse aerosol species in mechanism for washout (r>1 micrometer)
-   LOGICAL, DIMENSION(:), ALLOCATABLE :: aer_is_coarse
+  !---- Parameters
+  ! Minimum values for performing wet scavenging:
+  ! Aerosol MMR (µg/kg), cloud/precip water MMR (µg/kg), cloud/precip fraction
+  ! of cell area (0-1), loss fraction from wet scavenging process (0-1)
+  REAL, PARAMETER :: AER_MINVAL = 1.0E-12, WATER_MINVAL = 1.0E-12, &
+                     AERA_FRAC_MINVAL = 0.0001, LOSSFRAC_MINVAL = 1.0E-6
+  ! Scaling factor for resuspension rate, to take into account that
+  ! evaporation of hydrometeors can be incomplete. Value 0.5 from GEOS-CHEM
+  REAL, PARAMETER :: RESUSP_SCALING = 0.5
+  ! Flags for disabling in-cloud or below-cloud scavenging, or resuspension
+  LOGICAL, PARAMETER :: DO_RAINOUT = .true., DO_WASHOUT = .true., &
+                        DO_RESUSPENSION = .true.
+
+  ! chem_opt aerosol model family
+  LOGICAL :: aer_is_gocart
 
 CONTAINS
 
 !----------------------------------------------------------------------------
 
-   SUBROUTINE aer_wetscav_simple( id, dtstep, config_flags,                &
-                              t_phy, p_phy, dz8w, qsrflx,                  &
-                              chem, rho_phy, cldfra, rainprod, evapprod,   &
-                              precr, preci, precs, precg, dx, dy,          &
-                              qv, qc, qi, qs, qr, qg,                      &
-                              ids,ide, jds,jde, kds,kde,                   &
-                              ims,ime, jms,jme, kms,kme,                   &
-                              its,ite, jts,jte, kts,kte                    )
+  SUBROUTINE aer_wetscav_simple( chem, qsrflx, dtstep, config_flags,  &
+                             t_phy, rho_phy, dz8w,                        &
+                             cldfra, rainprod, evapprod,                  &
+                             precr, preci, precs, precg,                  &
+                             qv, qc, qi, qs, qr, qg,                      &
+                             ids,ide, jds,jde, kds,kde,                   &
+                             ims,ime, jms,jme, kms,kme,                   &
+                             its,ite, jts,jte, kts,kte                    )
 
-   ! Purpose:
-   ! Calculates and removes wet scavenging tendencies for aerosols
-   !
-   ! Arguments:
-   ! Input:
-   !   id = domain ID
-   !   dtstep = model time step (s)
-   !   config_flags = namelist configuration flags
-   !   t_phy = 3D physical temperature (K)
-   !   p_phy = 3D pressure (Pa)
-   !   dz8w = 3D vertical level depth (m)
-   !   rho_phy = 3D air density (kg/m3)
-   !   cldfra = 3D cloud fraction (unitless, 0-1)
-   !   rainprod = 3D rain production rate (kg/kg dry air/s)
-   !   evapprod = 3D rain evaporation rate (kg/kg dry air/s)
-   !   precr = 3D rain precipitation rate through grid cell (kg/m2/s)
-   !   preci = 3D ice precipitation rate through grid cell (kg/m2/s)
-   !   precs = 3D snow precipitation rate through grid cell (kg/m2/s)
-   !   precg = 3D graupel precipitation rate through grid cell (kg/m2/s)
-   !   dx, dy = model resolution in x and y (km)
-   !   qv = specific humidity = water vapor mixing ratio (kg/kg dry air)
-   !   qc = cloud water mixing ratio (kg/kg dry air)
-   !   qi = cloud ice mixing ratio (kg/kg dry air)
-   !   qs = snow water mixing ratio (kg/kg dry air)
-   !   qr = rain water mixing ratio (kg/kg dry air)
-   !   qg = graupel water mixing ratio (kg/kg dry air)
-   !   ids,ims,its etc. = domain, memory, and tile start and end indices
-   ! Input/output:
-   !   chem = advected chemical species (gases in ppm, aerosols in ug/kg)
-   ! Output:
-   !   qsrflx = aerosol column change due to scavenging (µg/m2)
+  ! Purpose:
+  ! Calculates and removes wet scavenging tendencies for aerosols
+  !
+  ! Arguments:
+  ! Input:
+  !   dtstep = model time step (s)
+  !   config_flags = namelist configuration flags
+  !   t_phy = 3D physical temperature (K)
+  !   dz8w = 3D vertical level depth (m)
+  !   rho_phy = 3D air density (kg/m3)
+  !   cldfra = 3D cloud fraction (unitless, 0-1)
+  !   rainprod = 3D rain production rate (kg/kg dry air/s)
+  !   evapprod = 3D rain evaporation rate (kg/kg dry air/s)
+  !   precr = 3D rain precipitation rate through grid cell (kg/m2/s)
+  !   preci = 3D ice precipitation rate through grid cell (kg/m2/s)
+  !   precs = 3D snow precipitation rate through grid cell (kg/m2/s)
+  !   precg = 3D graupel precipitation rate through grid cell (kg/m2/s)
+  !   qv = specific humidity = water vapor mixing ratio (kg/kg dry air)
+  !   qc = cloud water mixing ratio (kg/kg dry air)
+  !   qi = cloud ice mixing ratio (kg/kg dry air)
+  !   qs = snow water mixing ratio (kg/kg dry air)
+  !   qr = rain water mixing ratio (kg/kg dry air)
+  !   qg = graupel water mixing ratio (kg/kg dry air)
+  !   ids,ims,its etc. = domain, memory, and tile start and end indices
+  ! Input/output:
+  !   chem = advected chemical species (gases in ppm, aerosols in ug/kg)
+  ! Output:
+  !   qsrflx = aerosol column change due to scavenging (µg/m2)
 
-   ! USE associations:
-   !TODO Use ONLY:
-   USE module_configure
-   USE module_state_description
-   ! p_seas_1, p_seas_2, p_seas_3, p_seas_4, p_bc2, p_bc1, p_oc2, p_dust_1,
-   ! p_dust_2, p_dust_3, p_dust_4, p_sulf from module_state_description
-   ! USE module_data_gocart_seas, only: reff_seas
-   ! USE module_data_gocart_dust, only: reff_dust
+  ! USE associations:
+  USE module_configure, ONLY: param_first_scalar, num_chem, grid_config_rec_type
+  USE module_state_description, ONLY: &
+        p_seas_1, p_seas_2, p_seas_3, p_seas_4, p_dust_1, &
+        p_dust_2, p_dust_3, p_dust_4, p_dust_5
 
-   IMPLICIT NONE
+  IMPLICIT NONE
 
-   !---- Arguments
-   TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
-   INTEGER, INTENT(IN) :: ids,ide, jds,jde, kds,kde,    &
-                          ims,ime, jms,jme, kms,kme,    &
-                          its,ite, jts,jte, kts,kte,    &
-                          id
-   REAL, INTENT(IN) :: dx, dy
-   REAL, INTENT(IN) :: dtstep
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme)         ,        &
-       INTENT(IN) :: t_phy, p_phy, rho_phy, dz8w
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), &
-       INTENT(IN) :: qv, qi, qc, qs, qr, qg
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), &
-       INTENT(IN) :: rainprod, evapprod
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), &
-       INTENT(IN) :: precr, preci, precs, precg
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme)         ,        &
-       INTENT(IN) :: cldfra
-   REAL, DIMENSION(ims:ime, kms:kme, jms:jme, num_chem),          &
-       INTENT(INOUT) :: chem
-   REAL, DIMENSION(ims:ime, jms:jme, num_chem),          &
-         INTENT(OUT) :: qsrflx
+  !---- Arguments
+  TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
+  INTEGER, INTENT(IN) :: ids,ide, jds,jde, kds,kde,    &
+                         ims,ime, jms,jme, kms,kme,    &
+                         its,ite, jts,jte, kts,kte
+  REAL, INTENT(IN) :: dtstep
+  REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN) :: t_phy, rho_phy, &
+      dz8w, qv, qi, qc, qs, qr, qg, rainprod, evapprod, precr, preci, precs, &
+      precg, cldfra
+  REAL, DIMENSION(ims:ime,kms:kme,jms:jme,num_chem), INTENT(INOUT) :: chem
+  REAL, DIMENSION(ims:ime, jms:jme, num_chem),          &
+        INTENT(OUT) :: qsrflx
 
-   !---- Local variables and parameters
-   ! x,y,z, and chemical species index, chemical species pointer
-   INTEGER :: i, j, k, nv, p_chem
-   ! Cell fractions where rainout/washout is applied (See Luo et al., 2020)
-   REAL :: f, fr
-   ! Vertical dimension of cldfra for cloud fraction calculation
-   INTEGER :: dimz
-   ! Aerosol conc. in cloud phase: total cloud, ice-phase only, liquid-phase
-   ! only (µg/kg)
-   REAL :: cloudborne_aer, cloudborne_aer_ice, cloudborne_aer_liq
-   ! Aerosol conc. lost to rainout, aerosols conc. resuspended from precip
-   ! (µg/kg)
-   REAL :: rainout_aer, resusp_aer
-   ! Condensed cloud water mixing ratio (kg/kg dry air), precipitation mixing
-   ! ratio (kg/kg dry air), liquid fraction of cloud water (0-1)
-   REAL :: cloud_water, precip_water, liquid_fraction
-   ! Rainout activation efficiency of species (0-1)
-   REAL :: aq_aer_ratio_nv, ice_aer_ratio_nv
-   ! Total 3D precipitation trough cell for rain/snow/ice (kg/m2/hr), rain
-   ! production rate at i,k,j (kg/kg/s)
-   REAL :: ppr, pps, ppi, rainrate
-   ! Temperature (K)
-   REAL :: tk
-   ! Fraction of aerosol species washed out/rained out/resuspended (0-1)
-   REAL :: washfrac, rainfrac, resusp_frac
-   ! First-order rainout rate (s-1)
-   REAL :: k_rain
-   ! Value of chem(i,k,j,p) before deposition step (ug/kg)
-   REAL :: chem_spec_before
-   ! Flags for disabling in-cloud or below-cloud scavenging
-   LOGICAL :: DO_RAINOUT, DO_WASHOUT
+  !---- Local variables
+  ! x,y,z, and chemical species index, chemical species pointer
+  INTEGER :: i, j, k, iaer, p_chem
+  ! Cell fractions where rainout/washout is applied (See Luo et al., 2020)
+  REAL :: frac_rainout, frac_washout
+  ! Vertical dimension of cldfra for cloud fraction calculation
+  INTEGER :: dimz
+  ! Aerosol conc. in cloud phase, aerosol conc. lost to rainout, aerosols
+  ! conc. resuspended from precip (ug/kg)
+  REAL :: cloudborne_aer, rainout_aer, resusp_aer
+  ! Fraction of aerosols activated in clouds (0-1)
+  ! Total fraction, liquid clouds only, ice clouds only
+  REAL :: cloudborne_frac, cloudborne_frac_liq, cloudborne_frac_ice
+  ! Cloud water mixing ratio (kg/kg dry air), precipitation mixing ratio
+  ! (kg/kg dry air), liquid fraction of cloud water (0-1)
+  REAL :: cloud_water, precip_water, liquid_fraction
+  ! Rainout activation efficiency of species (0-1)
+  REAL :: aq_aer_ratio_iaer, ice_aer_ratio_iaer
+  ! Total 3D precipitation trough cell for rain/snow/ice (kg/m2/hr), rain
+  ! production rate at i,k,j (kg/kg/s)
+  REAL :: ppr, pps, ppi, rainrate
+  ! Temperature (K)
+  REAL :: tk
+  ! Cloud fraction at i,k,j (0D)
+  REAL :: cloud_fraction
+  ! Fraction of aerosol species washed out/rained out/resuspended (0-1)
+  REAL :: washfrac, rainfrac, resusp_frac
+  ! Efficiency of aerosol uptake in cloud water and cloud ice (0-1), for GOCART
+  REAL :: cloud_uptk_effic_liq, cloud_uptk_effic_ice
+  ! Conversion factor from /kg to /m2
+  REAL :: conv
+  ! 1D vertical arrays for rainfrac, wahsfrac, resusp_frac, cloud_aer_effic values
+  REAL, DIMENSION(kts:kte) :: rainfrac_1d, washfrac_fine_1d, washfrac_coarse_1d, resusp_frac_1d
+  REAL, DIMENSION(kts:kte) :: cloud_uptk_effic_liq_1d, cloud_uptk_effic_ice_1d
+  ! First-order rainout rate (s-1)
+  REAL :: k_rain
+  ! Value of chem(i,k,j,p) before deposition step (ug/kg)
+  REAL :: chem_spec_before
 
-   DO_RAINOUT = .true.
-   DO_WASHOUT = .true.
+  !-------- Perform wet scavenging for aerosol species -------
+  IF(DO_RAINOUT .OR. DO_WASHOUT) THEN
+  DO j=jts,jte
+  DO i=its,ite
+    !-- Initialize rainout, washout, resuspension parameters
+    frac_washout = 0.0
+    rainfrac_1d(kts:kte) = 0.0
+    washfrac_fine_1d(kts:kte) = 0.0
+    washfrac_coarse_1d(kts:kte) = 0.0
+    resusp_frac_1d(kts:kte) = 0.0
+    cloud_uptk_effic_liq_1d(kts:kte) = 1.0
+    cloud_uptk_effic_ice_1d(kts:kte) = 1.0
 
-   !-------- Perform wet scavenging for aerosol species -------
-   DO j=jts,jte
-     DO i=its,ite
-       fr = 0.0
-       deposition_flux(:) = 0.0
+    !---- Calculate parameters for rainout and washout schemes
+    DO k=kte-1,kts,-1 ! Do not change, needs to loop in descending order
 
-       DO k=kte-1,kts,-1 ! Do not change, needs to loop in descending order
-         !---- Calculate parameters for rainout and washout schemes
-         tk = t_phy(i, k, j)
-         ! Add rainprod back to cloud_water because rainprod was already
-         ! removed from cloud water in microphysics
-         cloud_water = qc(i,k,j) + qi(i,k,j) + rainprod(i,k,j)*dtstep
-         ! Add evapprod back to precip_water because evapprod was already
-         ! removed from precip in microphysics
-         precip_water = qr(i,k,j) + qs(i,k,j) + qg(i,k,j) &
-                        + evapprod(i,k,j)*dtstep
-         IF(cloud_water .GT. 1.0E-12) THEN
-           liquid_fraction = MIN(1.0, MAX(0.0, qc(i,k,j)/cloud_water))
-         ELSE
-           liquid_fraction = 1.0
-         ENDIF
-         rainrate = rainprod(i,k,j)
-         ! Total precipitation through grid cell in kg/m2/hr
-         ppr = precr(i,k,j) * 3600.
-         pps = precs(i,k,j) * 3600.
-         ppi = (preci(i,k,j) + precg(i,k,j)) * 3600.
-         ppr = MAX(ppr, 0.)
-         pps = MAX(pps, 0.)
-         ppi = MAX(ppi, 0.)
-         ! Calculate f, the precipitating fraction of the grid cell as defined
-         ! in Luo et al. (2020)
-         ! Also calculate rainfrac, the fraction of rained out aerosols
-         IF(cldfra(i, k, j) .GT. 0.001 .AND. cloud_water .GT. 1.0E-12 &
-            .AND. rainrate .GT. 0.0) THEN
-           CALL rainfrac_aerosol(rainfrac, f, rainrate, dtstep, cloud_water)
-         ELSE
-           rainfrac = 0.0
-           f = 0.0
-         END IF
-         ! The grid cell fraction experiencing washout, fr, is the max between f
-         ! at k and fr at k+1 (this is why we loop over k in descending order)
-         fr = MIN(1.0, MAX(fr, f))
+      !-- Initialize physical parameters at i,k,j
+      tk = t_phy(i, k, j)
+      cloud_fraction = cldfra(i,k,j)
+      ! Add rainprod back to cloud_water because rainprod was already
+      ! removed from cloud water in microphysics
+      cloud_water = qc(i,k,j) + qi(i,k,j) + rainprod(i,k,j)*dtstep
+      ! Add evapprod back to precip_water because evapprod was already
+      ! removed from precip in microphysics
+      precip_water = qr(i,k,j) + qs(i,k,j) + qg(i,k,j) &
+                     + evapprod(i,k,j)*dtstep
+      IF(cloud_water > WATER_MINVAL) THEN
+        liquid_fraction = qc(i,k,j) / cloud_water
+        liquid_fraction = MIN(1.0, MAX(0.0, liquid_fraction))
+      ELSE
+        liquid_fraction = 1.0
+      ENDIF
+      rainrate = rainprod(i,k,j)
+      ! Total precipitation through grid cell in kg/m2/hr
+      ppr = MAX(0., precr(i,k,j) * 3600.)
+      pps = MAX(0., precs(i,k,j) * 3600.)
+      ppi = MAX(0., (preci(i,k,j) + precg(i,k,j)) * 3600.)
 
-         DO nv = 1,naerspecies
-           p_chem = aer_pointers(nv)
+      !-- Calculate rainout parameters
+      ! frac_rainout is also needed to calculate frac_washout for washout
+      CALL calc_rainout_parameters( rainfrac, frac_rainout, &
+               cloud_uptk_effic_liq, cloud_uptk_effic_ice, &
+               tk, cloud_fraction, cloud_water, liquid_fraction, &
+               rainrate, dtstep)
+      rainfrac_1d(k) = rainfrac
+      cloud_uptk_effic_liq_1d(k) = cloud_uptk_effic_liq
+      cloud_uptk_effic_ice_1d(k) = cloud_uptk_effic_ice
 
-           !---- Perform rainout ("in-cloud scavenging")
-           IF(DO_RAINOUT .AND. f .GT. 0 .AND. cldfra(i,k,j) .GT. 0.001) THEN
+      !-- Calculate washout parameters
+      ! The grid cell fraction experiencing washout, frac_washout, is the
+      ! max between frac_rainout at k and frac_washout at k+1 (this is why
+      ! we loop over k in descending order)
+      frac_washout = MIN(1.0, MAX(frac_washout, frac_rainout))
+      IF(DO_WASHOUT .AND. ppr+pps+ppi > 0.0 &
+         .AND. frac_washout > AERA_FRAC_MINVAL) THEN
+        CALL washfrac_fine_aerosol(washfrac, ppr, pps, ppi, tk, &
+                                   frac_washout, dtstep)
+        washfrac_fine_1d(k) = washfrac
+        CALL washfrac_coarse_aerosol(washfrac, ppr, pps, ppi, tk, &
+                                     frac_washout, dtstep)
+        washfrac_coarse_1d(k) = washfrac
+      ENDIF ! DO_WASHOUT .AND. ...
 
-             !-- Calculate the mass concentration of cloudborne aerosols
-             ! Liquid-phase cloudborne aerosols
-             cloudborne_aer_liq = 0.0
-             aq_aer_ratio_nv = aq_aer_ratio(nv)
-             IF(tk .GT. 237.0 .AND. aq_aer_ratio_nv .GT. 0.0) THEN
-               cloudborne_aer_liq = chem(i,k,j,p_chem) * aq_aer_ratio_nv &
-                                * cldfra(i,k,j)
-               ! In mixed-phase clouds, correct by the liquid water fraction
-               IF(tk .LT. 273.0 .AND. liquid_fraction .GT. 0.0) THEN
-                 cloudborne_aer_liq = MIN(cloudborne_aer_liq,  &
-                                  chem(i,k,j,p_chem) * aq_aer_ratio_nv &
-                                  * cldfra(i,k,j) * liquid_fraction)
-               ENDIF
-             ENDIF ! aq_aer_ratio_nv .GT. 0.0 .AND. tk .GT. 237.0
-             ! Ice-phase cloudborne aerosols
-             cloudborne_aer_ice = 0.0
-             ice_aer_ratio_nv = ice_aer_ratio(nv)
-             IF(tk .LE. 237.0) THEN
-               ! 50 % activation efficiency in cold clouds (homogeneous
-               ! nucleation)
-               ice_aer_ratio_nv = 0.5
-               cloudborne_aer_ice = chem(i,k,j,p_chem) * cldfra(i,k,j)
-             ELSEIF(tk .LT. 258.0 .AND. ice_aer_ratio_nv .GT. 0.0) THEN
-               ! Reduce ice-phase scavenging efficiency at warmer temperatures
-               ! To take into account the temperature dependence of
-               ! heterogeneous nucleation
-               ice_aer_ratio_nv = ice_aer_ratio_nv &
-                                  * EXP(0.46*(273.16-tk)-11.6)/153.5
-               cloudborne_aer_ice = chem(i,k,j,p_chem) * ice_aer_ratio_nv &
-                                    * cldfra(i,k,j)
-               ! Correct by the ice fraction (1.0-liquid_fraction)
-               cloudborne_aer_ice = MIN(cloudborne_aer_ice,  &
-                                cloudborne_aer_ice * (1.0-liquid_fraction))
-             ELSE
-               ! At high temperatures ice nucleation is improbable so
-               ! cloudborne aerosol is 0
-               cloudborne_aer_ice = 0.0
-             ENDIF ! tk .LE. 237.0
+      !-- Calculate resuspension parameters
+      ! We apply resuspension to the total deposition flux from the column
+      ! above, so this assumes that the timescale of precipitation to level
+      ! k is smaller than dtstep
+      IF(DO_RESUSPENSION .AND. precip_water > WATER_MINVAL &
+         .AND. evapprod(i,k,j) > 0.) THEN
+        resusp_frac = RESUSP_SCALING * evapprod(i,k,j) * dtstep / precip_water
+        resusp_frac = MAX(0.0, MIN(1.0, resusp_frac))
+        resusp_frac_1d(k) = resusp_frac
+      END IF ! DO_RESUSPENSION .AND. ...
 
-             !-- Appply rainout to chem
-             cloudborne_aer = cloudborne_aer_liq + cloudborne_aer_ice
-             IF(cloudborne_aer .GT. 0.0) THEN
-               rainout_aer = rainfrac * cloudborne_aer
-               chem_spec_before = chem(i,k,j,p_chem)
-               chem(i,k,j,p_chem) = MAX(0.0, chem(i,k,j,p_chem) - rainout_aer)
-               deposition_flux(nv) = deposition_flux(nv) + (chem_spec_before - chem(i,k,j,p_chem)) &
-                                     * rho_phy(i,k,j) * dz8w(i,k,j)
-             ENDIF
-           ENDIF ! f .GT. 0 .AND. cldfra(i, k, j) .GT. 0.001
+    END DO ! k
 
+    !---- Perform rainout and washout
+    deposition_flux(:) = 0.0
+    DO iaer = 1,n_aer
+      ! Calculate rainout and washout by precip falling through the
+      ! vertical column
+      ! Do not change the loop order, needs to loop in descending order
+      DO k=kte-1,kts,-1
+        conv = rho_phy(i,k,j) * dz8w(i,k,j)
+        IF(aer_is_gocart) THEN
+          p_chem = aer_pointers(iaer)
+        ENDIF
 
-           !---- Perform washout ("below-cloud scavenging")
-           IF(DO_WASHOUT .AND. ppr+pps+ppi .GT. 0.0 .AND. fr .GT. 0.001) THEN
-             !-- Calculate washfrac, the fraction of washed out aerosols
-             ! Fine aerosol washout (r<=1 micrometer)
-             IF(aer_is_fine(nv)) THEN
-                CALL washfrac_fine_aerosol(washfrac, ppr, pps, ppi, tk, fr, dtstep)
-             ! Coarse aerosol washout (r>1 micrometer)
-             ELSEIF(aer_is_coarse(nv)) THEN
-                CALL washfrac_coarse_aerosol(washfrac, ppr, pps, ppi, tk, fr, dtstep)
-             ! Any other aerosol is not washed out
-             ELSE
-               washfrac = 0.0
-             END IF
-             !-- Apply washout to chem
-             IF(washfrac .GT. 0.0) THEN
-               chem_spec_before = chem(i,k,j,p_chem)
-               chem(i,k,j,p_chem) = MAX(0.0, (1.0-washfrac) * chem(i,k,j,p_chem))
-               deposition_flux(nv) = deposition_flux(nv) + (chem_spec_before - chem(i,k,j,p_chem)) &
-                                     * rho_phy(i,k,j) * dz8w(i,k,j)
-             ENDIF
-           END IF ! ppr+pps+ppi .GT. 0 .AND. fr .GT. 0.01
+        !---- Perform rainout ("in-cloud scavenging")
+        IF(DO_RAINOUT .AND. rainfrac_1d(k) > LOSSFRAC_MINVAL) THEN
+          !-- Rainout: calculate the mass concentration of cloudborne aerosols
+          IF(aer_is_gocart) THEN
+            !- GOCART: Liquid-phase cloudborne aerosols for rainout
+            aq_aer_ratio_iaer = aq_aer_ratio(iaer)
+            cloudborne_frac_liq = aq_aer_ratio_iaer*cloud_uptk_effic_liq_1d(k)
+            !- GOCART: Ice-phase cloudborne aerosols for rainout
+            IF(tk <= 237.0) THEN
+              ! Homogeneous nucleation - In cold clouds, all aerosols can
+              ! activate, but reduce the max activation to 50% as in Luo
+              ! (2019, 2010)
+              ice_aer_ratio_iaer = 0.5
+            ELSE
+              ! Heterogeneous nucleation - In mixed-phase clouds, ice
+              ! activation is only possible for INP
+              ice_aer_ratio_iaer = ice_aer_ratio(iaer)
+            ENDIF
+            cloudborne_frac_ice = ice_aer_ratio_iaer*cloud_uptk_effic_ice_1d(k)
+          ELSE
+            CALL wrf_error_fatal('aer_wetscav_simple: unknown chem_opt')
+          ENDIF ! aer_is_gocart
+
+          !-- Appply rainout to chem
+          IF(cloudborne_frac_liq > 0.0 .OR. cloudborne_frac_ice > 0.) THEN
+            !- GOCART: apply rainout
+            IF(aer_is_gocart) THEN
+              ! Remove GOCART mass
+              IF(p_chem > param_first_scalar) THEN
+                cloudborne_frac = cloudborne_frac_liq+cloudborne_frac_ice
+                CALL remove_aer(aerconc=chem(i,k,j,p_chem), &
+                                dep_flux=deposition_flux(iaer), &
+                                lossfrac=rainfrac_1d(k)*cloudborne_frac, &
+                                conv=conv)
+              ENDIF
+            ELSE
+              CALL wrf_error_fatal('aer_wetscav_simple: unknown chem_opt')
+            ENDIF ! aer_is_gocart
+          ENDIF
+
+        ENDIF ! DO_RAINOUT .AND. ...
 
 
-           !---- Perform resuspension of aerosols from evaporating precip. water
-           ! We apply resuspension to the total deposition flux from the column
-           ! above, so this assumes that the timescale of precipitation to level
-           ! k is smaller than dtstep
-           IF(precip_water .GT. 0. .AND. evapprod(i,k,j) .GT. 0.) THEN
-             ! Scale by 0.5 as in GEOS-Chem, to take into account that
-             ! evaporation of hydrometeors can be incomplete
-             resusp_frac = 0.5 * evapprod(i,k,j) * dtstep / precip_water
-             resusp_frac = MAX(0.0, MIN(1.0, resusp_frac))
-             resusp_aer = (resusp_frac * deposition_flux(nv) / (rho_phy(i,k,j) * dz8w(i,k,j)))
-             chem(i,k,j,p_chem) = MAX(0.0, chem(i,k,j,p_chem) + resusp_aer)
-             deposition_flux(nv) = deposition_flux(nv) * (1.0 - resusp_frac)
-           END IF
+        !---- Perform washout ("below-cloud scavenging")
+        IF(DO_WASHOUT .AND. (washfrac_fine_1d(k) > LOSSFRAC_MINVAL &
+                        .OR. washfrac_coarse_1d(k) > LOSSFRAC_MINVAL)) THEN
+          !-- Calculate washfrac, the fraction of washed out aerosols
+          ! Fine aerosol washout (diam<=2 micrometer)
+          IF(aer_dry_diam(iaer) <= 2.0E-6) THEN
+            washfrac = washfrac_fine_1d(k)
+          ! Coarse aerosol washout (diam>2 micrometer)
+          ELSEIF(aer_dry_diam(iaer) > 2.0E-6) THEN
+            washfrac = washfrac_coarse_1d(k)
+          ELSE
+            washfrac = 0.0
+          END IF
 
-         END DO ! nv
-       END DO ! k
+          !-- Apply washout to chem
+          IF(washfrac > 0.0) THEN
+            !- GOCART: apply washout
+            IF(aer_is_gocart) THEN
+              ! Remove GOCART mass
+              IF(p_chem > param_first_scalar) THEN
+                CALL remove_aer(aerconc=chem(i,k,j,p_chem), &
+                                dep_flux=deposition_flux(iaer), &
+                                lossfrac=washfrac, conv=conv)
+              ENDIF
+            ELSE
+              CALL wrf_error_fatal('aer_wetscav_simple: unknown chem_opt')
+            ENDIF
+          ENDIF
 
-       !---- Output deposition fluxes
-       DO nv = 1,naerspecies
-         p_chem = aer_pointers(nv)
-         IF(p_chem > param_first_scalar) THEN
-           ! WRF-Chem convention is negative from atmosphere to the ground
-           qsrflx(i,j,p_chem) = -deposition_flux(nv)
-         ENDIF
-       END DO ! nv
+        END IF ! DO_WASHOUT .AND. ...
 
-     END DO ! i
-   END DO ! j
 
-   END SUBROUTINE aer_wetscav_simple
+        !---- Perform resuspension of aerosols from evaporating precip. water
+        ! We apply resuspension to the total deposition flux from the column
+        ! above
+        IF(DO_RESUSPENSION .AND. resusp_frac_1d(k) > LOSSFRAC_MINVAL) THEN
+          !-- GOCART: apply resuspension
+          IF(aer_is_gocart .AND. p_chem > param_first_scalar) THEN
+            ! Resuspend GOCART mass
+            IF(p_chem > param_first_scalar) THEN
+              resusp_aer = resusp_frac_1d(k) * deposition_flux(iaer) / conv
+              chem(i,k,j,p_chem) = MAX(0.0, chem(i,k,j,p_chem) + resusp_aer)
+              deposition_flux(iaer) = deposition_flux(iaer) * (1.0 - resusp_frac_1d(k))
+            END IF
+          ELSE
+            CALL wrf_error_fatal('aer_wetscav_simple: unknown chem_opt')
+          ENDIF ! aer_is_gocart
+        END IF ! DO_RESUSPENSION .AND. ...
 
-!----------------------------------------------------------------------------
+      END DO ! k
 
-   SUBROUTINE rainfrac_aerosol(rainfrac, f, rainrate, dtstep, cloud_water)
+      !---- Output deposition fluxes
+      IF(aer_is_gocart) THEN
+        p_chem = aer_pointers(iaer)
+        IF(p_chem > param_first_scalar) THEN
+          ! WRF-Chem convention is negative from atmosphere to the ground
+          qsrflx(i,j,p_chem) = -deposition_flux(iaer)
+        ENDIF
+      ENDIF
 
-     ! Purpose:
-     ! Calculates rainfrac, the fraction of cloudborne aerosols lost to rainout.
-     !
-     ! Arguments:
-     ! Input:
-     !   rainrate - precipitation formation rate (kg/kg/s)
-     !   dtstep - time step (s)
-     !   cloud_water - condensed cloud water mixing ratio (kg/kg)
-     ! Output:
-     !   rainfrac - fraction of aerosols lost to rainout (unitless)
-     !   f - rainout area fraction (unitless)
-     !
-     ! Remarks:
-     ! From GEOS-Chem, Luo et al (2020)
+    END DO ! iaer
 
-     IMPLICIT NONE
+  END DO ! i
+  END DO ! j
+  ENDIF ! DO_RAINOUT .OR. DO_WASHOUT
 
-     ! Arguments
-     REAL, INTENT(IN) :: rainrate
-     REAL, INTENT(IN) :: dtstep
-     REAL, INTENT(INOUT) :: cloud_water
-     REAL, INTENT(OUT) :: rainfrac
-     REAL, INTENT(OUT) :: f
-     ! Local variables and parameters
-     REAL :: k_rain ! first-order rainout rate (s-1)
-     REAL,  PARAMETER :: k_0 = 1.0E-4 ! s-1
-
-     ! Do not allow more than 100% of the cloud water to precipitate
-     cloud_water = MAX(rainrate*dtstep, cloud_water)
-     k_rain = k_0 + rainrate / cloud_water
-     ! Area of grid box undergoing precipitation
-     f = rainrate / (k_rain * cloud_water)
-     f = MIN(f, 1.0)
-     ! Fraction of aerosols lost to rainout
-     rainfrac = f * (1.0 - EXP(-k_rain*dtstep))
-
-   END SUBROUTINE rainfrac_aerosol
+  END SUBROUTINE aer_wetscav_simple
 
 !----------------------------------------------------------------------------
 
-   SUBROUTINE washfrac_fine_aerosol(washfrac, ppr, pps, ppi, tk, fr, dtstep)
+  SUBROUTINE calc_rainout_parameters(rainfrac, frac_rainout, &
+     cloud_uptk_effic_liq, cloud_uptk_effic_ice, &
+     tk, cloud_fraction, cloud_water, &
+     liquid_fraction, rainrate, dtstep)
 
-     ! Purpose:
-     ! Calculates washfrac, the fraction of fine (r_eff < 1 µm) aerosols
-     ! lost to washout.
-     !
-     ! Arguments:
-     ! Input:
-     !   ppr = rain precipitation through cell (kg/m2/hr = mm/hr)
-     !   pps = snow precipitation through cell (kg/m2/hr = mm/hr)
-     !   ppi = ice precipitation through cell (kg/m2/hr = mm/hr)
-     !   tk = temperature (K)
-     !   fr = fraction of cell experiencing washout
-     !   dtstep - time step (s)
-     ! Output:
-     !   washfrac - fraction of aerosols lost to washout (unitless)
-     !
-     ! Comments:
-     ! From GEOS-Chem, Luo et al (2020), using GC12 parameters
+    ! Purpose:
+    ! Calculates parameters for aerosol rainout wet scavenging
+    !
+    ! Arguments:
+    ! Input:
+    !   tk = temperature (K)
+    !   cloud_fraction = cloud fraction (0-1)
+    !   liquid_fraction = fraction of cloud water in liquid form (0-1)
+    !   rainrate = precipitation formation rate (kg/kg/s)
+    !   dtstep = time step (s)
+    ! Input/Output
+    !   cloud_water = cloud water mixing ratio (kg/kg)
+    ! Output:
+    !   rainfrac = fraction of aerosols lost to rainout (unitless)
+    !   frac_rainout = rainout area fraction (unitless)
+    !   cloud_uptk_effic_liq = efficiency of aerosol uptake in cloud water
+    !   cloud_uptk_effic_ice = efficiency of aerosol uptake in cloud ice
 
-     IMPLICIT NONE
+    IMPLICIT NONE
 
-     ! Arguments
-     REAL, INTENT(IN) :: ppr
-     REAL, INTENT(IN) :: pps
-     REAL, INTENT(IN) :: ppi
-     REAL, INTENT(IN) :: tk
-     REAL, INTENT(IN) :: fr
-     REAL, INTENT(IN) :: dtstep
-     REAL, INTENT(OUT) :: washfrac
+    !-- Arguments
+    REAL, INTENT(IN) :: tk, cloud_fraction, liquid_fraction, rainrate, dtstep
+    REAL, INTENT(INOUT) :: cloud_water
+    REAL, INTENT(OUT) :: rainfrac, frac_rainout, cloud_uptk_effic_liq, &
+                         cloud_uptk_effic_ice
 
-     ! Local variables
-     REAL :: lossrate_rain,lossrate_snow,lossrate_ice,lossrate
+    !-- Calculate frac_rainout, the precipitating fraction of the grid cell as defined
+    ! in Luo et al. (2020)
+    ! Also calculate rainfrac, the fraction of rained out aerosols
+    rainfrac = 0.0
+    frac_rainout = 0.0
+    IF(cloud_fraction > AERA_FRAC_MINVAL &
+       .AND. cloud_water > WATER_MINVAL &
+       .AND. rainrate > 0.0) THEN
+      CALL rainfrac_aerosol(rainfrac, frac_rainout, rainrate, dtstep, &
+                            cloud_water)
+    END IF
 
-     ! Calculate wet removal rate from each precip type
-     lossrate_rain = 4.3E-6 * (ppr/fr)**0.61
-     lossrate_snow = 8.8E-6 * (pps/fr)**0.96
-     lossrate_ice = 8.8E-6/5.0 * (ppi/fr)**0.96
+    !-- Scaling factors for cloudborne aerosol uptake efficiency, for rainout
+    cloud_uptk_effic_liq = 1.0
+    cloud_uptk_effic_ice = 0.0
+    IF(DO_RAINOUT .AND. cloud_fraction > AERA_FRAC_MINVAL) THEN
+      !- Liquid-phase cloudborne aerosol uptake efficiency for rainout
+      IF(tk > 237.0) THEN
+        cloud_uptk_effic_liq = cloud_fraction
+        ! In mixed-phase clouds, correct by the liquid water fraction
+        IF(tk < 273. .AND. liquid_fraction > 0.0) THEN
+          cloud_uptk_effic_liq = MIN(cloud_uptk_effic_liq,  &
+                                    cloud_uptk_effic_liq*liquid_fraction)
+        ENDIF
+      ENDIF ! tk > 237.0
+      !- Ice-phase cloudborne aerosol uptake efficiency for rainout
+      IF(tk <= 237.0) THEN
+        ! Cold clouds - Uptake by homogeneous nucleation = 100%
+        cloud_uptk_effic_ice = cloud_fraction
+      ELSEIF(tk < 258.0) THEN
+        ! Mixed-phase clouds - Uptake by heterogeneous nucleation
+        cloud_uptk_effic_ice = cloud_fraction
+        ! Reduce ice-phase scavenging efficiency at warmer temperatures
+        ! To take into account the temperature dependence of
+        ! heterogeneous nucleation
+        cloud_uptk_effic_ice = cloud_uptk_effic_ice &
+                             * EXP(0.46*(273.16-tk)-11.6)/153.5
+        ! Correct by the ice fraction (1.0-liquid_fraction)
+        cloud_uptk_effic_ice = MIN(cloud_uptk_effic_ice, &
+                                cloud_uptk_effic_ice &
+                                * (1.0 - liquid_fraction))
+      ELSE
+        ! At high temperatures ice nucleation is improbable so
+        ! cloudborne aerosol is 0
+        cloud_uptk_effic_ice = 0.0
+      ENDIF ! tk <= 237.0
+    ENDIF ! DO_RAINOUT .AND. ...
 
-     ! Calculate total wet removal rate and washout fraction
-     lossrate = lossrate_rain+lossrate_snow+lossrate_ice
-     washfrac = fr * (1.0 - EXP(-lossrate*dtstep))
-
-   END SUBROUTINE washfrac_fine_aerosol
-
-!----------------------------------------------------------------------------
-
-   SUBROUTINE washfrac_coarse_aerosol(washfrac, ppr, pps, ppi, tk, fr, dtstep)
-
-     ! Purpose:
-     ! Calculates washfrac, the fraction of coarse (r_eff > 1 µm) aerosols lost
-     ! to washout.
-     !
-     ! Arguments:
-     ! Input:
-     !   ppr = rain precipitation through cell (kg/m2/hr = mm/hr)
-     !   pps = snow precipitation through cell (kg/m2/hr = mm/hr)
-     !   ppi = ice precipitation through cell (kg/m2/hr = mm/hr)
-     !   tk = temperature (K)
-     !   fr = fraction of cell experiencing washout
-     !   dtstep - time step (s)
-     ! Output:
-     !   washfrac - fraction of aerosols lost to washout (unitless)
-     !
-     ! Comments:
-     ! From GEOS-Chem, Luo et al (2020), using GC12 parameters
-
-     IMPLICIT NONE
-
-     ! Arguments
-     REAL, INTENT(IN) :: ppr
-     REAL, INTENT(IN) :: pps
-     REAL, INTENT(IN) :: ppi
-     REAL, INTENT(IN) :: tk
-     REAL, INTENT(IN) :: fr
-     REAL, INTENT(IN) :: dtstep
-     REAL, INTENT(OUT) :: washfrac
-
-     ! Local variables
-     REAL :: lossrate_rain,lossrate_snow,lossrate_ice,lossrate
-
-     ! Calculate wet removal rate from each precip type
-     lossrate_rain = 2.6E-4 * (ppr/fr)**0.79
-     lossrate_snow = 4.2E-4 * (pps/fr)**0.96
-     lossrate_ice = 4.2E-4/5.0 * (ppi/fr)**0.96
-
-     ! Calculate total wet removal rate and washout fraction
-     lossrate = lossrate_rain+lossrate_snow+lossrate_ice
-     washfrac = fr * (1.0 - EXP(-lossrate*dtstep))
-
-   END SUBROUTINE washfrac_coarse_aerosol
+  END SUBROUTINE calc_rainout_parameters
 
 !----------------------------------------------------------------------------
 
-   SUBROUTINE aer_wetscav_simple_init(chem_opt)
+  SUBROUTINE rainfrac_aerosol(rainfrac, frac_rainout, rainrate, dtstep, &
+                              cloud_water)
 
-     ! Purpose
-     !  Initialize aer_wetscav_simple parameters, which depend on chem_opt
-     !
-     ! Arguments
-     !  chem_opt TODO
-     !
-     ! Remarks
-     !  TODO
+    ! Purpose:
+    ! Calculates rainfrac, the fraction of cloudborne aerosols lost to rainout.
+    !
+    ! Arguments:
+    ! Input:
+    !   rainrate - precipitation formation rate (kg/kg/s)
+    !   dtstep - time step (s)
+    !   cloud_water - cloud water mixing ratio (kg/kg)
+    ! Output:
+    !   rainfrac - fraction of aerosols lost to rainout (unitless)
+    !   frac_rainout - rainout area fraction (unitless)
+    !
+    ! Remarks:
+    ! From GEOS-Chem, Luo et al (2020)
 
-     USE module_state_description ! For chem_opt option values
+    IMPLICIT NONE
 
-     IMPLICIT NONE
+    ! Arguments
+    REAL, INTENT(IN) :: rainrate
+    REAL, INTENT(IN) :: dtstep
+    REAL, INTENT(INOUT) :: cloud_water
+    REAL, INTENT(OUT) :: rainfrac
+    REAL, INTENT(OUT) :: frac_rainout
+    ! Local variables and parameters
+    REAL :: k_rain ! first-order rainout rate (s-1)
+    REAL,  PARAMETER :: k_0 = 1.0E-4 ! s-1
 
-     ! Arguments
-     !  Input
-     INTEGER, INTENT(IN) :: chem_opt
+    ! Do not allow more than 100% of the cloud water to precipitate
+    cloud_water = MAX(rainrate*dtstep, cloud_water)
+    k_rain = k_0 + rainrate / cloud_water
+    ! Area of grid box undergoing precipitation
+    frac_rainout = rainrate / (k_rain * cloud_water)
+    frac_rainout = MIN(frac_rainout, 1.0)
+    ! Fraction of aerosols lost to rainout
+    rainfrac = frac_rainout * (1.0 - EXP(-k_rain*dtstep))
 
-    !-------- Initialize aerosol tracer number for chem_opt --------
-    ! This could be recovered from the aerosol scheme data directly
-    IF(chem_opt == MOZCART_KPP .OR. chem_opt == GOCART_SIMPLE) THEN
-      ! MOZCART
-      naerspecies = 13
+  END SUBROUTINE rainfrac_aerosol
+
+!----------------------------------------------------------------------------
+
+  SUBROUTINE washfrac_fine_aerosol(washfrac, ppr, pps, ppi, tk, &
+                                   frac_washout, dtstep)
+
+    ! Purpose:
+    ! Calculates washfrac, the fraction of fine (r_eff < 1 µm) aerosols
+    ! lost to washout.
+    !
+    ! Arguments:
+    ! Input:
+    !   ppr = rain precipitation through cell (kg/m2/hr = mm/hr)
+    !   pps = snow precipitation through cell (kg/m2/hr = mm/hr)
+    !   ppi = ice precipitation through cell (kg/m2/hr = mm/hr)
+    !   tk = temperature (K)
+    !   frac_washout = fraction of cell experiencing washout
+    !   dtstep - time step (s)
+    ! Output:
+    !   washfrac - fraction of aerosols lost to washout (unitless)
+    !
+    ! Comments:
+    ! From GEOS-Chem, Luo et al (2020), using GC12 parameters
+
+    IMPLICIT NONE
+
+    ! Arguments
+    REAL, INTENT(IN) :: ppr
+    REAL, INTENT(IN) :: pps
+    REAL, INTENT(IN) :: ppi
+    REAL, INTENT(IN) :: tk
+    REAL, INTENT(IN) :: frac_washout
+    REAL, INTENT(IN) :: dtstep
+    REAL, INTENT(OUT) :: washfrac
+
+    ! Local variables
+    REAL :: lossrate_rain,lossrate_snow,lossrate_ice,lossrate
+
+    ! Calculate wet removal rate from each precip type
+    lossrate_rain = 4.3E-6 * (ppr/frac_washout)**0.61
+    lossrate_snow = 8.8E-6 * (pps/frac_washout)**0.96
+    lossrate_ice = 8.8E-6/5.0 * (ppi/frac_washout)**0.96
+
+    ! Calculate total wet removal rate and washout fraction
+    lossrate = lossrate_rain+lossrate_snow+lossrate_ice
+    washfrac = frac_washout * (1.0 - EXP(-lossrate*dtstep))
+
+  END SUBROUTINE washfrac_fine_aerosol
+
+!----------------------------------------------------------------------------
+
+  SUBROUTINE washfrac_coarse_aerosol(washfrac, ppr, pps, ppi, tk, &
+                                     frac_washout, dtstep)
+
+    ! Purpose:
+    ! Calculates washfrac, the fraction of coarse (r_eff > 1 µm) aerosols lost
+    ! to washout.
+    !
+    ! Arguments:
+    ! Input:
+    !   ppr = rain precipitation through cell (kg/m2/hr = mm/hr)
+    !   pps = snow precipitation through cell (kg/m2/hr = mm/hr)
+    !   ppi = ice precipitation through cell (kg/m2/hr = mm/hr)
+    !   tk = temperature (K)
+    !   frac_washout = fraction of cell experiencing washout
+    !   dtstep - time step (s)
+    ! Output:
+    !   washfrac - fraction of aerosols lost to washout (unitless)
+    !
+    ! Comments:
+    ! From GEOS-Chem, Luo et al (2020), using GC12 parameters
+
+    IMPLICIT NONE
+
+    ! Arguments
+    REAL, INTENT(IN) :: ppr
+    REAL, INTENT(IN) :: pps
+    REAL, INTENT(IN) :: ppi
+    REAL, INTENT(IN) :: tk
+    REAL, INTENT(IN) :: frac_washout
+    REAL, INTENT(IN) :: dtstep
+    REAL, INTENT(OUT) :: washfrac
+
+    ! Local variables
+    REAL :: lossrate_rain,lossrate_snow,lossrate_ice,lossrate
+
+    ! Calculate wet removal rate from each precip type
+    lossrate_rain = 2.6E-4 * (ppr/frac_washout)**0.79
+    lossrate_snow = 4.2E-4 * (pps/frac_washout)**0.96
+    lossrate_ice = 4.2E-4/5.0 * (ppi/frac_washout)**0.96
+
+    ! Calculate total wet removal rate and washout fraction
+    lossrate = lossrate_rain+lossrate_snow+lossrate_ice
+    washfrac = frac_washout * (1.0 - EXP(-lossrate*dtstep))
+
+  END SUBROUTINE washfrac_coarse_aerosol
+ 
+!----------------------------------------------------------------------------
+
+  SUBROUTINE remove_aer(aerconc, dep_flux, lossfrac, conv)
+
+    ! Purpose
+    !  Remove fraction lossfrac of aerosol concentration aerconc, and
+    !  accumulate the resulting deposition flux to dep_flux
+    !
+    ! Arguments
+    !  aerconc = aerosol concentration (mass/kg or number/kg)
+    !  dep_flux = accumulated deposition flux (mass/m2 or number/m2)
+    !  lossfrac = fraction of aerosol concentration to remove (0-1)
+    !  conv = conversion factor from kg-1 to m-2
+
+    IMPLICIT NONE
+
+    ! Arguments
+    REAL, INTENT(INOUT) :: aerconc, dep_flux
+    REAL, INTENT(IN) :: lossfrac, conv
+
+    ! Local variables
+    REAL :: aerconc_before,aerconc_loss
+
+    ! Deposit aerosols and calculate deposition flux
+    aerconc_before = aerconc
+    aerconc_loss = lossfrac * aerconc
+    aerconc = MAX(0.0, aerconc - aerconc_loss)
+    dep_flux = dep_flux + (aerconc_before - aerconc) * conv
+
+  END SUBROUTINE remove_aer
+
+!----------------------------------------------------------------------------
+
+  SUBROUTINE aer_wetscav_simple_init(chem_opt)
+
+    ! Purpose
+    !  Initialize aer_wetscav_simple parameters, which depend on chem_opt
+    !
+    ! Arguments
+    !  chem_opt = chemistry option from config_flags, from namelist
+
+    USE module_state_description, ONLY: MOZCART_KPP, &
+        T1_MOZCART_KPP, GOCART_SIMPLE, GOCARTRADM2,GOCARTRACM_KPP, &
+        p_seas_1, p_seas_2, p_seas_3, p_seas_4, p_bc2, p_oc2, p_dust_1, &
+        p_dust_2, p_dust_3, p_dust_4, p_dust_5, p_sulf
+
+    IMPLICIT NONE
+
+    ! Arguments
+    !  Input
+    INTEGER, INTENT(IN) :: chem_opt
+
+    !---- Initialize chem mechanism families IDs
+    aer_is_gocart = chem_opt == MOZCART_KPP .OR. &
+                    chem_opt == T1_MOZCART_KPP .OR. &
+                    chem_opt == GOCART_SIMPLE .OR. &
+                    chem_opt == GOCARTRADM2 .OR. &
+                    chem_opt == GOCARTRACM_KPP
+
+    !-------- Initialize number of aerosols for chem_opt --------
+    IF(aer_is_gocart) THEN
+      ! GOCART
+      n_aer = 12
     ELSE
       CALL wrf_error_fatal ('wetscav_simple_init: chem_opt not supported')
     ENDIF
 
     !---- Allocate aerosol mappings and parameters for wet scavenging
+    IF (.NOT. ALLOCATED(aer_dry_diam)) THEN
+      ALLOCATE(aer_dry_diam(n_aer))
+    ENDIF
+    IF(aer_is_gocart) THEN
+      IF (.NOT. ALLOCATED(deposition_flux)) THEN
+        ALLOCATE(deposition_flux(n_aer))
+      ENDIF
+    ENDIF
     IF (.NOT. ALLOCATED(aer_pointers)) THEN
-      ALLOCATE(aer_pointers(naerspecies))
+      ALLOCATE(aer_pointers(n_aer))
     ENDIF
     IF (.NOT. ALLOCATED(aq_aer_ratio)) THEN
-      ALLOCATE(aq_aer_ratio(naerspecies))
+      ALLOCATE(aq_aer_ratio(n_aer))
     ENDIF
     IF (.NOT. ALLOCATED(ice_aer_ratio)) THEN
-      ALLOCATE(ice_aer_ratio(naerspecies))
-    ENDIF
-    IF (.NOT. ALLOCATED(aer_is_fine)) THEN
-      ALLOCATE(aer_is_fine(naerspecies))
-    ENDIF
-    IF (.NOT. ALLOCATED(aer_is_coarse)) THEN
-      ALLOCATE(aer_is_coarse(naerspecies))
-    ENDIF
-    IF (.NOT. ALLOCATED(deposition_flux)) THEN
-      ALLOCATE(deposition_flux(naerspecies))
+      ALLOCATE(ice_aer_ratio(n_aer))
     ENDIF
 
     !---- Initialize aerosol mappings and parameters for wet scavenging
-    deposition_flux(:) = 0.0
-    IF(chem_opt == MOZCART_KPP .OR. chem_opt == GOCART_SIMPLE) THEN
+    IF(aer_is_gocart) THEN
       !-- GOCART
       ! Species that experience wet scavenging (sulfate deposition needs to
       ! be disabled in mozcart_wetscav)
       aer_pointers(:) = (/ p_sulf, p_seas_1, p_seas_2, p_seas_3, p_seas_4, &
                            p_bc2, p_oc2, p_dust_1, p_dust_2, p_dust_3, &
-                           p_dust_4, p_dust_5, p_bc1 /)
+                           p_dust_4, p_dust_5 /)
+      ! Aerosol effective diameters (µm) for aer_pointers species
+      aer_dry_diam(:) = (/ 0.312E-6, 0.6E-6, 2.0E-6, 6.5E-6, 15.0E-6, &
+                           0.078E-6, 0.174E-6, 1.46E-6, 2.8E-6, 4.8E-6, &
+                           9.0E-6, 16.0E-6 /)
       ! Fraction of activated aerosols for aer_pointers species
       ! We do not use the values from Luo et al. (2020) because they are
       ! mostly sensitive to hygroscopicity, even though size is more important
@@ -523,28 +686,18 @@ CONTAINS
       ! are inefficient CCN
       aq_aer_ratio(:) = (/ 0.5, 0.5, 0.5, 0.5, 0.5, &
                            0.5, 0.5, 0.5, 0.5, 0.5, &
-                           0.5, 0.5, 0. /)
+                           0.5, 0.5 /)
       ! Activated fraction in ice clouds is usually very low except at very low
-      ! temperatures, even for efficient INP - pick 0.5 for now but it could
-      ! be lower
+      ! temperatures, even for efficient INP - pick 0.5 for now but the true
+      ! value is probably lower
       ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., &
                             0., 0., 0.5, 0.5, 0.5, &
-                            0.5, 0.5, 0. /)
-      ! List of washed out fine aerosol for aer_pointers species (r<=1
-      ! micrometer)
-      aer_is_fine(:) = (/ .true., .true., .true., .false., .false., &
-                          .true., .true. , .true., .false., .false., &
-                          .false., .false., .false. /)
-      ! List of washed out coarse aerosol for aer_pointers species (r>1
-      ! micrometer)
-      aer_is_coarse(:) = (/ .false., .false., .false., .true., .true., &
-                            .false., .false., .false., .true., .true., &
-                            .true., .true., .false. /)
+                            0.5, 0.5 /)
     ELSE
       CALL wrf_error_fatal ('wetscav_simple_init: chem_opt not supported')
     ENDIF
 
-   END SUBROUTINE aer_wetscav_simple_init
+  END SUBROUTINE aer_wetscav_simple_init
 
 !----------------------------------------------------------------------------
 

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -65,7 +65,7 @@ CONTAINS
                              t_phy, rho_phy, dz8w,                        &
                              cldfra, rainprod, evapprod,                  &
                              precr, preci, precs, precg,                  &
-                             qv, qc, qi, qs, qr, qg,                      &
+                             qc, qi, qs, qr, qg,                          &
                              ids,ide, jds,jde, kds,kde,                   &
                              ims,ime, jms,jme, kms,kme,                   &
                              its,ite, jts,jte, kts,kte                    )
@@ -87,7 +87,6 @@ CONTAINS
   !   preci = 3D ice precipitation rate through grid cell (kg/m2/s)
   !   precs = 3D snow precipitation rate through grid cell (kg/m2/s)
   !   precg = 3D graupel precipitation rate through grid cell (kg/m2/s)
-  !   qv = specific humidity = water vapor mixing ratio (kg/kg dry air)
   !   qc = cloud water mixing ratio (kg/kg dry air)
   !   qi = cloud ice mixing ratio (kg/kg dry air)
   !   qs = snow water mixing ratio (kg/kg dry air)
@@ -114,7 +113,7 @@ CONTAINS
                          its,ite, jts,jte, kts,kte
   REAL, INTENT(IN) :: dtstep
   REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN) :: t_phy, rho_phy, &
-      dz8w, qv, qi, qc, qs, qr, qg, rainprod, evapprod, precr, preci, precs, &
+      dz8w, qi, qc, qs, qr, qg, rainprod, evapprod, precr, preci, precs, &
       precg, cldfra
   REAL, DIMENSION(ims:ime,kms:kme,jms:jme,num_chem), INTENT(INOUT) :: chem
   REAL, DIMENSION(ims:ime, jms:jme, num_chem),          &

--- a/chem/module_wetscav_driver.F
+++ b/chem/module_wetscav_driver.F
@@ -418,7 +418,6 @@ REAL,  DIMENSION( ims:ime , kms:kme , jms:jme , ntot_amode ),       &
                                  evapprod=evaprate, &
                                  precr=precr, preci=preci, &
                                  precs=precs, precg=precg, &
-                                 qv=moist(ims,kms,jms,p_qv), &
                                  qc=moist(ims,kms,jms,p_qc), &
                                  qi=moist(ims,kms,jms,p_qi), &
                                  qs=moist(ims,kms,jms,p_qs), &
@@ -521,7 +520,6 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
                              evapprod=evaprate, &
                              precr=precr, preci=preci, &
                              precs=precs, precg=precg, &
-                             qv=moist(ims,kms,jms,p_qv), &
                              qc=moist(ims,kms,jms,p_qc), &
                              qi=moist(ims,kms,jms,p_qi), &
                              qs=moist(ims,kms,jms,p_qs), &

--- a/chem/module_wetscav_driver.F
+++ b/chem/module_wetscav_driver.F
@@ -411,19 +411,25 @@ REAL,  DIMENSION( ims:ime , kms:kme , jms:jme , ntot_amode ),       &
        ! gases
        IF(config_flags%chem_opt == MOZCART_KPP .OR. config_flags%chem_opt == T1_MOZCART_KPP) THEN
          CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
-         CALL aer_wetscav_simple( id, dtstep, config_flags,                     &
-                                  t_phy, p_phy, dz8w, qsrflx,                   &
-                                  chem, rho_phy, cldfra_ls, rainrate, evaprate, &
-                                  precr, preci, precs, precg, dx, dy,           &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qv),          &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qc),          &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qi),          &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qs),          &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qr),          &
-                                  moist(ims:ime,kms:kme,jms:jme,p_qg),          &
-                                  ids,ide, jds,jde, kds,kde,                    &
-                                  ims,ime, jms,jme, kms,kme,                    &
-                                  its,ite, jts,jte, kts,kte                     )
+         CALL aer_wetscav_simple(chem=chem, qsrflx=qsrflx, dtstep=dtstep, &
+                                 config_flags=config_flags, t_phy=t_phy, &
+                                 rho_phy=rho_phy, dz8w=dz8w, &
+                                 cldfra=cldfra_ls, rainprod=rainrate, &
+                                 evapprod=evaprate, &
+                                 precr=precr, preci=preci, &
+                                 precs=precs, precg=precg, &
+                                 qv=moist(ims,kms,jms,p_qv), &
+                                 qc=moist(ims,kms,jms,p_qc), &
+                                 qi=moist(ims,kms,jms,p_qi), &
+                                 qs=moist(ims,kms,jms,p_qs), &
+                                 qr=moist(ims,kms,jms,p_qr), &
+                                 qg=moist(ims,kms,jms,p_qg), &
+                                 ids=ids,ide=ide, jds=jds, jde=jde, &
+                                 kds=kds, kde=kde, &
+                                 ims=ims,ime=ime, jms=jms, jme=jme, &
+                                 kms=kms, kme=kme, &
+                                 its=its,ite=ite, jts=jts, jte=jte, &
+                                 kts=kts, kte=kte)
        ENDIF
 
         hno3_col_mdel = delta_mass_col(:,:,p_hno3)
@@ -508,19 +514,25 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
        evaprate(:,:,:) = 0.
      endif
      CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
-     CALL aer_wetscav_simple( id, dtstep, config_flags,                     &
-                              t_phy, p_phy, dz8w, qsrflx,                   &
-                              chem, rho_phy, cldfra_ls, rainrate, evaprate, &
-                              precr, preci, precs, precg, dx, dy,           &
-                              moist(ims:ime,kms:kme,jms:jme,p_qv),          &
-                              moist(ims:ime,kms:kme,jms:jme,p_qc),          &
-                              moist(ims:ime,kms:kme,jms:jme,p_qi),          &
-                              moist(ims:ime,kms:kme,jms:jme,p_qs),          &
-                              moist(ims:ime,kms:kme,jms:jme,p_qr),          &
-                              moist(ims:ime,kms:kme,jms:jme,p_qg),          &
-                              ids,ide, jds,jde, kds,kde,                    &
-                              ims,ime, jms,jme, kms,kme,                    &
-                              its,ite, jts,jte, kts,kte                     )
+     CALL aer_wetscav_simple(chem=chem, qsrflx=qsrflx, dtstep=dtstep, &
+                             config_flags=config_flags, t_phy=t_phy, &
+                             rho_phy=rho_phy, dz8w=dz8w, &
+                             cldfra=cldfra_ls, rainprod=rainrate, &
+                             evapprod=evaprate, &
+                             precr=precr, preci=preci, &
+                             precs=precs, precg=precg, &
+                             qv=moist(ims,kms,jms,p_qv), &
+                             qc=moist(ims,kms,jms,p_qc), &
+                             qi=moist(ims,kms,jms,p_qi), &
+                             qs=moist(ims,kms,jms,p_qs), &
+                             qr=moist(ims,kms,jms,p_qr), &
+                             qg=moist(ims,kms,jms,p_qg), &
+                             ids=ids,ide=ide, jds=jds, jde=jde, &
+                             kds=kds, kde=kde, &
+                             ims=ims,ime=ime, jms=jms, jme=jme, &
+                             kms=kms, kme=kme, &
+                             its=its,ite=ite, jts=jts, jte=jte, &
+                             kts=kts, kte=kte)
    CASE DEFAULT
 
    END SELECT cps_select


### PR DESCRIPTION
Refactor the simple aerosol wet scavenging module in 
chem/module_aer_wetscav_simple.F, with the following changes:
- Enables the module for all GOCART aerosol mechanisms.
- Pre-calculates some aerosol-independent physical parameters for rainout,
   washout and resuspension and store them to avoid recalculating them each
   time for each aerosol type in the iaer loop.
- Select the coarse vs. fine washout functions directly based on aerosol size 
   instead of precalculated aer_is_fine, aer_is_coarse arrays.
- Changes the order of the vertical level loop and aerosol species loop so that
   the code can be used in the future with internally mixed aerosols such as
   MOSAIC. For GOCART, the aerosol index iaer points to individual aerosol
   components. With MOSAIC, iaer will point to bin number and it will be possible
   to add an extra loop on aerosol subcomponents for a given bin iaer and
   vertical level k.
- Move more code into subroutines to simplify the top-level aer_wetscav_simple
   routine and reuse code more efficiently.
- Remove some unused arguments and local variables.
- Remove most "magic numbers" from the code and add parameters for the
   different physical thresholds.
- Fix the formatting, remove TODOs from the code.

This fixes issue #66 