### PR TITLE
Update DMS sea-air flux parameterization

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -103,9 +103,6 @@ state    real  e_so4i         i+jf     emis_ant     1         Z      i5r     "E_
 state    real  e_so4j         i+jf     emis_ant     1         Z      i5r     "E_SO4J"              "EMISSION RATE OF J-MODE ORG. AER."   "ug/m3 m/s"
 state    real  e_no3i         i+jf     emis_ant     1         Z      i5r     "E_NO3I"              "EMISSION RATE OF I-MODE ORG. AER."   "ug/m3 m/s"
 state    real  e_no3j         i+jf     emis_ant     1         Z      i5r     "E_NO3J"              "EMISSION RATE OF J-MODE ORG. AER."   "ug/m3 m/s"
-#LMarelle: Additional DMS oceanic content for DMS emissions. This should be
-#somewhere else than emis_ant at some point since this is not anthropogenic
-state    real  e_dms_oc       i+jf     emis_ant     1         Z      i5r     "E_DMS_OC"            "OCEANIC SURFACE DMS CONTENT"          "mol/m3"
 # Additional MOZART emission variables...
 state    real  e_nh4i         i+jf     emis_ant     1         Z      i5r     "E_NH4I"              "EMISSION RATE OF I-MODE ORG. AER."   "ug/m3 m/s"
 state    real  e_nh4j         i+jf     emis_ant     1         Z      i5r     "E_NH4J"              "EMISSION RATE OF J-MODE ORG. AER."   "ug/m3 m/s"
@@ -615,7 +612,8 @@ state    real  wdflx          ijo     misc        1         Z      r       "WET_
 
 state    real  e_nacl_ocean   ij      misc        1         Z      rh      "E_NACL_OCEAN"       "Ocean NaCl emiss"               "ug m^-2"
 state    real  e_nacl_blow    ij      misc        1         Z      rh      "E_NACL_BLOW"        "Blowing snow NaCl emiss"        "ug m^-2"
-state    real  e_nacl_leads    ij      misc        1         Z      rh      "E_NACL_LEADS"        "Leads NaCl emiss"        "ug m^-2"
+state    real  e_nacl_leads   ij      misc        1         Z      rh      "E_NACL_LEADS"       "Leads NaCl emiss"               "ug m^-2"
+state    real  e_dms_ocean    ij      misc        1         Z      rh      "E_DMS_OCEAN"        "Ocean DMS emiss"                "mol m^-2"
 
 #
 state    real  e_bio          ijo     misc        1         Z      r        "E_BIO"             "EMISSIONS"             "ppm m/min"
@@ -4157,13 +4155,12 @@ package   ecbmz_mosaic    emiss_opt==4                   -             emis_ant:
 package   ecptec          emiss_opt==5                   -             emis_ant:e_iso,e_so2,e_no,e_no2,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_pm_25,e_pm_10,e_oc,e_sulf,e_bc
 package   gocart_ecptec   emiss_opt==6                   -             emis_ant:e_so2,e_sulf,e_bc,e_oc,e_pm_25,e_pm_10
 package   mozem           emiss_opt==7                   -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_nh3,e_isop,e_c10h16,e_sulf
-package   mozcem          emiss_opt==8                   -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_nh3,e_isop,e_c10h16,e_dms_oc,e_pm_10,e_pm_25,e_bc,e_oc,e_sulf
+package   mozcem          emiss_opt==8                   -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_nh3,e_isop,e_c10h16,e_pm_10,e_pm_25,e_bc,e_oc,e_sulf
 package   cammam          emiss_opt==9                   -             emis_ant:e_iso,e_so2,e_no,e_co,e_eth,e_hc3,e_hc5,e_hc8,e_xyl,e_ol2,e_olt,e_oli,e_tol,e_csl,e_hcho,e_ald,e_ket,e_ora2,e_nh3,e_dms,e_ecj,e_orgj,e_so4i,e_so4j,e_soag_bigene,e_soag_isoprene,e_soag_terpene,e_soag_toluene,e_dust_a1,e_dust_a3,e_ncl_a1,e_ncl_a2,e_ncl_a3,e_orgj_num,e_ecj_num,e_so4j_num,e_so4i_num
 
-package   mozmem           emiss_opt==10                   -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_benzene,e_xylene,e_nh3,e_isop,e_apin,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_nh4i,e_nh4j,e_nai,e_naj,e_cli,e_clj,e_co_a,e_orgi_a,e_orgj_a,e_co_bb,e_orgi_bb,e_orgj_bb,e_pm_10,e_c2h2,e_gly,e_sulf,e_macr,e_mgly,e_mvk,e_hcooh,e_hono,e_dms_oc,e_hcl
+package   mozmem           emiss_opt==10                   -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_benzene,e_xylene,e_nh3,e_isop,e_apin,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_nh4i,e_nh4j,e_nai,e_naj,e_cli,e_clj,e_co_a,e_orgi_a,e_orgj_a,e_co_bb,e_orgi_bb,e_orgj_bb,e_pm_10,e_c2h2,e_gly,e_sulf,e_macr,e_mgly,e_mvk,e_hcooh,e_hono,e_hcl
 package   mozc_t1_em      emiss_opt==11                  -             emis_ant:e_co,e_no,e_no2,e_bigalk,e_bigene,e_c2h4,e_c2h5oh,e_c2h6,e_c3h6,e_c3h8,e_ch2o,e_ch3cho,e_ch3coch3,e_ch3oh,e_mek,e_so2,e_toluene,e_nh3,e_isop,e_hcooh,e_ch3cn,e_ch3cooh,e_hcn,e_apin,e_mvk,e_mgly,e_benzene,e_xylene,e_sulf,e_c2h2,e_pm_10,e_pm_25,e_bc,e_oc
-#LMarelle: Add e_dms_oc, DMS oceanic content in mol/m3 (technically, this should not be in emis_ant)
-package   esaprcnov       emiss_opt==13                  -             emis_ant:e_so2,e_c2h6,e_c3h8,e_c2h2,e_alk3,e_alk4,e_alk5,e_ethene,e_c3h6,e_ole1,e_ole2,e_aro1,e_aro2,e_hcho,e_ccho,e_rcho,e_acet,e_mek,e_isoprene,e_terp,e_sesq,e_co,e_no,e_no2,e_phen,e_cres,e_meoh,e_gly,e_mgly,e_bacl,e_isoprod,e_methacro,e_mvk,e_prod2,e_ch4,e_bald,e_hcooh,e_cco_oh,e_rco_oh,e_nh3,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb,e_dms_oc
+package   esaprcnov       emiss_opt==13                  -             emis_ant:e_so2,e_c2h6,e_c3h8,e_c2h2,e_alk3,e_alk4,e_alk5,e_ethene,e_c3h6,e_ole1,e_ole2,e_aro1,e_aro2,e_hcho,e_ccho,e_rcho,e_acet,e_mek,e_isoprene,e_terp,e_sesq,e_co,e_no,e_no2,e_phen,e_cres,e_meoh,e_gly,e_mgly,e_bacl,e_isoprod,e_methacro,e_mvk,e_prod2,e_ch4,e_bald,e_hcooh,e_cco_oh,e_rco_oh,e_nh3,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_orgi_a,e_orgj_a,e_orgi_bb,e_orgj_bb
 # For CB05 mechanism based on CBMZ speciation, used with emiss_inpt_opt = 102 
 package   ecb05_opt1      emiss_opt==14                   -             emis_ant:e_no2,e_xyl,e_tol,e_terp,e_so2,e_ora2,e_olt,e_oli,e_ol2,e_no,e_nh3,e_iso,e_hcl,e_hcho,e_eth,e_csl,e_co,e_ch3oh,e_c2h5oh,e_ald,e_aldx,e_hc3,e_hc5,e_hc8,e_ket,e_pm25i,e_pm25j,e_eci,e_ecj,e_orgi,e_orgj,e_so4i,e_so4j,e_no3i,e_no3j,e_so4c,e_no3c,e_orgc,e_ecc,e_pm10
 # For CB05 emissions inventory base on CB05 speciation, used with emiss_inpt_opt = 101
@@ -4242,7 +4239,9 @@ package   seasgong      seas_opt==7                  -                -
 package   seassalter    seas_opt==8                  -                -
 package   dmsgocart     dmsemis_opt==1               -                -
 package   dmsn2000_old  dmsemis_opt==2               -                -
-package   dmsnightingale   dms_opt==1                -                -
+package   dms_nightingale  dms_opt==1                -                -
+package   dms_lm1986       dms_opt==2                -                -
+package   dms_w2014        dms_opt==3                -                -
 package   volume_approx    aer_op_opt==1                -             -
 package   maxwell_approx   aer_op_opt==2                -             -
 package   volume_exact     aer_op_opt==3                -             -

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -926,6 +926,7 @@
               grid%mebio_acet,grid%mebio_mbo,grid%mebio_no,                                &
               current_month,                                                               &
               grid%lakemask,grid%e_nacl_ocean,grid%e_nacl_blow,grid%e_nacl_leads,          &
+              grid%e_dms_ocean,                                                            &
          ! stuff for LNOx emissions
              grid%ht, grid%refl_10cm, grid%ic_flashrate, grid%cg_flashrate,                 &
          ! stuff for aircraft emissions

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -65,6 +65,7 @@ CONTAINS
          mebio_acet, mebio_mbo, mebio_no,                                  &
          current_month,                                                    &
          lakemask, e_nacl_ocean, e_nacl_blow, e_nacl_leads,                &
+         e_dms_ocean,                                                      &
          ! end stuff for MEGAN v2.04
          ! stuff for LNOx emissions
          ht, refl_10cm,                                                    &
@@ -330,7 +331,8 @@ CONTAINS
            adapt_step_flag
 
       REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: lakemask
-      REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_nacl_ocean, e_nacl_blow, e_nacl_leads
+      REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_nacl_ocean, &
+               e_nacl_blow, e_nacl_leads, e_dms_ocean
 
 !     stuff for aircraft emissions
 
@@ -864,9 +866,9 @@ real, save :: freq_industry(24)    = &
       END SELECT dust_select
 
       dms_select:  SELECT CASE(config_flags%dms_opt)
-      CASE(DMSNIGHTINGALE)
+      CASE(DMS_NIGHTINGALE, DMS_LM1986, DMS_W2014)
         CALL dms_emis( id, dtstep, dz8w, config_flags%dms_opt,      &
-         rho_phy, chem,                                             &
+         rho_phy, p_phy, chem, e_dms_ocean,                         &
          u10, v10, xland, tsk, xice, lakemask, dms_ocean,           &
          ids,ide, jds,jde, kds,kde,                                 &
          ims,ime, jms,jme, kms,kme,                                 &

--- a/chem/module_dms_emis.F
+++ b/chem/module_dms_emis.F
@@ -1,4 +1,4 @@
-! 2025/03 Louis Marelle, Rémy lapere
+! 2026 Louis Marelle, Rémy lapere
 !
 ! Purpose:
 !  Compute DMS emissions
@@ -10,25 +10,34 @@
 ! References:
 ! ==============================================================================
 ! Air-sea exchange functions:
-!  (1) Nightingale et al., 2000: https://doi.org/10.1029/1999GB900091
+!   Nightingale et al., 2000: https://doi.org/10.1029/1999GB900091
+!   Liss and Merlivat, 1986: https://doi.org/10.1007/978-94-009-4738-2_5
+!   Wanninkhof, 2014: https://doi.org/10.4319/lom.2014.12.351
 ! Schmidt number for DMS
-!  (1) Saltzman et al., 1993: https://doi.org/10.1029/93JC01858
+!   Saltzman et al., 1993: https://doi.org/10.1029/93JC01858
+!   Wanninkhof, 2014: https://doi.org/10.4319/lom.2014.12.351
+! Henry's Law Coefficient for DMS
+!   Sander, 2015: https://doi.org/10.5194/acp-15-4399-2015
 ! Sea ice correction factor
-!  (1) Loose et al., 2009: doi:10.1029/2008GL036318
+!   Loose et al., 2009: doi:10.1029/2008GL036318
 ! Implementation and evaluation:
-!  (1) Marelle et al., 2017: doi:10.5194/gmd-10-3661-2017
-!  (2) Lapere et al., 2025: in prep.
+!   Marelle et al., 2017: doi:10.5194/gmd-10-3661-2017
+!   Lapere et al., 2025: https://dx.doi.org/10.22541/au.175466602.22534100/v1
 
 MODULE module_dms_emis
 
   IMPLICIT NONE
+
+  !---- Parameters
+  ! Schmidt number for co2 at 20°C = 600 (reference value)
+  REAL, PARAMETER :: SC_CO2 = 600.
 
   CONTAINS
 
 !------------------------------------------------------------------------------
 
   SUBROUTINE dms_emis( id, dtstep, dz8w, dms_opt,                   &
-         rho_phy, chem,                            &
+         rho_phy, p_phy, chem, e_dms_ocean,                         &
          u10, v10, xland, tsk, xice, lakemask, dms_ocean,           &
          ids,ide, jds,jde, kds,kde,                                 &
          ims,ime, jms,jme, kms,kme,                                 &
@@ -44,6 +53,7 @@ MODULE module_dms_emis
     !  dz8w = 3D vertical level depth (m)
     !  dms_opt = dms emission option from config_flags
     !  rho_phy = 3D air density (kg/m3)
+    !  p_phy = 3D air pressure (Pa)
     !  u10 = windpeed at 10m in x (positive west-east) direction (m/s)
     !  v10 = windpeed at 10m in y (positive south-north) direction (m/s)
     !  xland = landmask flag (1 land, 2 water)
@@ -54,6 +64,7 @@ MODULE module_dms_emis
     !  ids,ims,its etc. = domain, memory, and tile start and end indices
     ! Input/output
     !  chem = advected chemical species (gases in ppm, aerosols in microg/kg)
+    !  e_dms_ocean = accumulated DMS emissions (mol/m2)
 
     USE module_state_description
 
@@ -68,34 +79,37 @@ MODULE module_dms_emis
                            its,ite, jts,jte, kts,kte
     REAL, INTENT(IN) :: dtstep
     REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(IN) :: dz8w, &
-                                                              rho_phy
+                                                    rho_phy, p_phy
     REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: u10, v10, xland, &
                                           tsk, xice, lakemask, dms_ocean
     ! Input/output
     REAL, DIMENSION(ims:ime, kms:kme, jms:jme, num_chem), &
         INTENT(INOUT) :: chem
+    REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_dms_ocean
 
     !---- Local variables
     ! DMS emission flux (mol km-2 hr-1)
     REAL :: dms_emiss
-    ! Surface oceanic dms content in mol/m^3
-    REAL :: dms_ocean_sfc
+    ! Oceanic DMS content in water (mol m-3)
+    REAL :: c_dms_water
+    ! Oceanic DMS content in water-air interface (mol m-3)
+    REAL :: c_dms_interface
+    ! Henry's Law coefficient for DMS (mol m-3 Pa-1)
+    REAL :: h_dms
+    ! DMS partial pressure in air (Pa)
+    REAL :: press_dms
+    ! Schmidt number for DMS (dimensionless)
+    REAL :: sc_dms
+    ! Sea-air exchange coefficient for DMS (cm hour-1)
+    REAL :: kw_dms
     ! 10-m wind (m/s), sea surface temperature (celsius)
     REAL :: w10, sst
-    ! Schmidt number for DMS
-    REAL :: sc_dms
-    ! Sea-air exchange coefficient for DMS (m/hour)
-    REAL :: k_dms
     ! Conversion factor from mol km-2 hr-1 to ppmv
     REAL :: conv
     ! Sea ice fraction
     REAL :: icefrac
     ! Indices
     INTEGER :: i, j
-
-    !---- Parameters
-    ! Schmidt number for co2 at 20°C = 600 (reference value)
-    REAL, PARAMETER :: sc_co2=600.
 
     !-------- Compute DMS emissions --------
 
@@ -109,34 +123,38 @@ MODULE module_dms_emis
         icefrac = xice(i,j)
         IF ( (xland(i,j) .GT. 1.5 &
             .OR. (icefrac .GT. 1.E-9 .AND. icefrac .LT. 1.0)) ) THEN
-!Could exclude lakes            .AND. lakemask(i,j) .LT. 0.5) THEN
 
           !-------- Initialize DMS emission parameters --------
           dms_emiss = 0.0
-          ! DMS surface concentration in mol/m3
-          dms_ocean_sfc = dms_ocean(i,j)*1.E-6
+          ! DMS concentration in water - nmol L-1 to mol m-3
+          c_dms_water = dms_ocean(i,j)*1.E-6
 
-          IF(dms_ocean_sfc > 0.) THEN
+          IF(c_dms_water > 0.) THEN
             ! 10-m wind speed (m/s)
             w10 = SQRT(u10(i, j)**2.0 + v10(i, j)**2.0)
             ! Conversion factor from mol km-2 hr-1 to ppmv
             conv = 4.828e-4 / rho_phy(i,kts,j) * dtstep / (dz8w(i,kts,j) * 60.)
+            ! Sea surface temperature, from skin temperature
+            sst = tsk(i,j)
 
-            !---- DMS emission flux from Nightingale et al. (2000)
-            IF(dms_opt == DMSNIGHTINGALE) THEN
-              ! SST - Schmidt number parameterization valid 5 to 30°C
-              sst = ( tsk(i,j) - 273.15 )
-              sst = MAX(MIN(sst, 30.0), 5.0)
-              ! Schmidt number for DMS (Saltzman et al., 1993)
-              sc_dms = 2674.0 - 147.12 * sst + 3.726 * sst ** 2.0 &
-                          - 0.038 * sst ** 3
-              ! Sea - air exchange coefficient from Nightingale et al. 2000 (m/hour)
-              ! k_dms = ( 0.222*w10**2 + 0.333*w10) * (sc_dms/sc_co2)**(-0.5) / 3600. / 100.
-              k_dms = (0.00222*w10**2 + 0.00333*w10) * (sc_dms/sc_co2)**(-0.5)
-              ! DMS emission flux in mol m-2 hour-1
-              dms_emiss = k_dms * dms_ocean_sfc
-              ! Convert to  WRF-Chem units (mol km-2 hour-1)
-              dms_emiss = dms_emiss * 1.0E6
+
+            !---- Calculate the sea-air exchange coefficient
+            kw_dms = 0.
+            sc_dms = 0.
+            ! Sea-air exchange coefficient for DMS from Nightingale et al. (2000)
+            IF(dms_opt == DMS_NIGHTINGALE) THEN
+               CALL schmidt_saltzman1993(sc_dms=sc_dms, sst=sst)
+               CALL k_emis_n2000(kw_dms=kw_dms, sc_dms=sc_dms, w10=w10)
+
+            ! Sea-air exchange coefficient for DMS from Liss and Merlivat (1986)
+            ELSEIF(dms_opt == DMS_LM1986) THEN
+               CALL schmidt_saltzman1993(sc_dms=sc_dms, sst=sst)
+               CALL k_emis_lm1986(kw_dms=kw_dms, sc_dms=sc_dms, w10=w10)
+
+            ! Sea-air exchange coefficient for DMS from Wanninkhof (2014)
+            ELSEIF(dms_opt == DMS_W2014) THEN
+               CALL schmidt_wanninkhof2014(sc_dms=sc_dms, sst=sst)
+               CALL k_emis_w2014(kw_dms=kw_dms, sc_dms=sc_dms, w10=w10)
 
             ELSE
               !---- Other dms_opt cases are not supported
@@ -144,20 +162,209 @@ MODULE module_dms_emis
 
             ENDIF ! dms_opt
 
-            ! Account for fractional sea ice (Loose et al., 2009)
+            !---- Calculate DMS emissions
+            !-- Calculate the DMS concentration in water at the interface
+            ! Henry's Law coefficient for DMS (Sander2015 eq. 19 and Table 6)
+            h_dms = 5.6E-3 * EXP(3500.* (1./sst - 1/298.15))
+            press_dms = 1.E-6 * chem(i,kts,j,p_dms) * p_phy(i,kts,j)
+            c_dms_interface =  press_dms * h_dms
+            !-- Calculate the DMS emission flux
+            ! In practice c_interface is often << c_water - could maybe
+            ! neglect
+            IF(c_dms_water > c_dms_interface) THEN
+              ! e.g. Wanninkhof2014 eq. 1
+              dms_emiss = kw_dms/100. * (c_dms_water-c_dms_interface)
+            ELSE
+              dms_emiss = 0.
+            END IF
+            ! Account for fractional sea ice (Loose2009 Fig. 3)
             IF(icefrac > 0.01) THEN
               dms_emiss = dms_emiss*(1.0-icefrac)**0.4
             ENDIF
-            ! Add emissions to chem, at the surface
+            ! Convert to  WRF-Chem units (mol km-2 hour-1)
+            dms_emiss = dms_emiss * 1.0E6
+
+            !---- Add emissions to chem, at the surface
             IF(p_dms > param_first_scalar) THEN
               chem(i,kts,j,p_dms) = chem(i,kts,j,p_dms) + dms_emiss*conv
             ENDIF
 
-          ENDIF ! dms_ocean_sfc
+            ! Accumulate DMS emissions for output (mol/m2)
+            e_dms_ocean(i,j) = e_dms_ocean(i,j) &
+                               + dms_emiss * 1.E-6 / 3600. * dtstep
+
+          ENDIF ! c_dms_water
         END IF ! xland
       END DO ! j
     END DO ! i
 
   END SUBROUTINE dms_emis
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE schmidt_wanninkhof2014(sc_dms, sst)
+    !
+    ! Purpose:
+    !   Calculate the schmidt coefficient of DMS based on Wanninkhof (2014)
+
+    ! References:
+    !   Wanninkhof (2014): https://doi.org/10.4319%2Flom.2014.12.351
+
+    ! Arguments:
+    !   Input:
+    !     sst = Sea surface temperature (K)
+    !   Output:
+    !     sc_dms = Schmidt number for DMS (dimensionless)
+
+    !---- Arguments
+    REAL, INTENT(OUT) :: sc_dms
+    REAL, INTENT(IN) :: sst
+
+    !---- Local variables
+    ! Sea surface temperature, corrected (°C)
+    REAL :: sst_corr
+
+    ! SST - Schmidt number parameterization valid -2 to 40°C
+    sst_corr = sst - 273.15
+    sst_corr = MAX(MIN(sst_corr, 40.0), -2.0)
+    ! Schmidt number for DMS (Wanninkhof2014 Table 2)
+    sc_dms = 2855.7 - 177.63*sst_corr + 6.0438*sst_corr**2.0 &
+             - 0.11645*sst_corr**3. + 0.00094743*sst_corr**4.
+    ! Different equation for fresh water, could be used for lakes
+    ! sc_dms = 2595. - 163.12*sst_corr + 5.5902*sst_corr**2.0 &
+    !          - 0.10817*sst_corr**3. + 0.00088204*sst_corr**4.
+
+  END SUBROUTINE schmidt_wanninkhof2014
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE schmidt_saltzman1993(sc_dms, sst)
+    !
+    ! Purpose:
+    !   Calculate the schmidt coefficient of DMS based on Saltzman et al., 1993
+
+    ! References:
+    !   Saltzman et al., 1993: https://doi.org/10.1029/93JC01858
+
+    ! Arguments:
+    !   Input:
+    !     sst = Sea surface temperature (K)
+    !   Output:
+    !     sc_dms = Schmidt number for DMS (dimensionless)
+
+    !---- Arguments
+    REAL, INTENT(OUT) :: sc_dms
+    REAL, INTENT(IN) :: sst
+
+    !---- Local variables
+    ! Sea surface temperature, corrected (°C)
+    REAL :: sst_corr
+
+    ! SST - Schmidt number parameterization valid 5 to 30°C
+    sst_corr = sst - 273.15
+    sst_corr = MAX(MIN(sst_corr, 30.0), 5.0)
+    ! Schmidt number for DMS (Saltzman1993)
+    sc_dms = 2674.0 - 147.12*sst_corr + 3.726*sst_corr**2.0 &
+                - 0.038*sst_corr**3.
+
+  END SUBROUTINE schmidt_saltzman1993
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE k_emis_w2014(kw_dms, sc_dms,  w10)
+    !
+    ! Purpose:
+    !  Calculate DMS exchange coefficent from sea surface to the atmosphere
+    !  using the parameterization of Wanninkhof (2014)
+
+    ! References:
+    !   Wanninkhof (2014): https://doi.org/10.4319%2Flom.2014.12.351
+
+    ! Arguments:
+    !   Input:
+    !     sc_dms = Schmidt number for DMS (dimensionless)
+    !     w10 = 10-m wind speed (m s-1)
+    !   Output:
+    !     kw_dms = Sea-air exchange coefficient for DMS (cm hour-1)
+
+    IMPLICIT NONE
+
+    !---- Arguments
+    REAL, INTENT(OUT) :: kw_dms
+    REAL, INTENT(IN) :: sc_dms
+    REAL, INTENT(IN) :: w10
+
+    ! Sea-air exchange coefficient (Wanninkhof2014 eq. 11)
+    kw_dms = 0.251 * w10**2 * (sc_dms/660.)**(-0.5)
+
+  END SUBROUTINE k_emis_w2014
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE k_emis_n2000(kw_dms, sc_dms,  w10)
+    !
+    ! Purpose:
+    !  Calculate DMS exchange coefficent from sea surface to the atmosphere
+    !  using the parameterization of Nightingale et al. (2000)
+
+    ! References:
+    !   Nightingale et al., 2000: https://doi.org/10.1029/1999GB900091
+
+    ! Arguments:
+    !   Input:
+    !     sc_dms = Schmidt number for DMS (dimensionless)
+    !     w10 = 10-m wind speed (m s-1)
+    !   Output:
+    !     kw_dms = Sea-air exchange coefficient for DMS (cm hour-1)
+
+    IMPLICIT NONE
+
+    !---- Arguments
+    REAL, INTENT(OUT) :: kw_dms
+    REAL, INTENT(IN) :: sc_dms
+    REAL, INTENT(IN) :: w10
+
+    ! Sea-air exchange coefficient, Nightingale2000 Sect. 5.2 and eq. 2
+    kw_dms = (0.222*w10**2 + 0.333*w10) * (sc_dms/SC_CO2)**(-0.5)
+
+  END SUBROUTINE k_emis_n2000
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE k_emis_lm1986(kw_dms, sc_dms, w10)
+    !
+    ! Purpose:
+    !  Calculate DMS exchange coefficient from sea surface to the atmosphere
+    !  using the parameterization of Liss and Merlivat (1986)
+
+    ! References:
+    !   Liss and Merlivat, 1986: https://doi.org/10.1007/978-94-009-4738-2_5
+
+    ! Arguments:
+    !   Input:
+    !     sc_dms = Schmidt number for DMS (dimensionless)
+    !     w10 = 10-m wind speed (m s-1)
+    !   Output:
+    !     kw_dms = Sea-air exchange coefficient for DMS (cm hour-1)
+
+    IMPLICIT NONE
+
+    !---- Arguments
+    REAL, INTENT(OUT) :: kw_dms
+    REAL, INTENT(IN) :: sc_dms
+    REAL, INTENT(IN) :: w10
+
+    ! Sea-air exchange coefficient (LissMerlivat1986 eqs. 7, 8, 9)
+    IF(w10 <= 3.6) THEN
+      kw_dms = 0.17*w10 * (sc_dms/SC_CO2)**(-0.66666666)
+    ELSE IF(w10 <= 13.) THEN
+      kw_dms = (2.85*w10 - 9.65) * (sc_dms/SC_CO2)**(-0.5)
+    ELSE
+      kw_dms = (5.9*w10 - 49.3) * (sc_dms/SC_CO2)**(-0.5)
+    END IF
+
+  END SUBROUTINE k_emis_lm1986
+
+!------------------------------------------------------------------------------
 
 END MODULE module_dms_emis

--- a/polar-options.md
+++ b/polar-options.md
@@ -25,7 +25,7 @@ This option controls the primary marine organic emissions in sea-spray. Only com
 This option controls the sea-spray emissions from sea ice leads. Only compatible with seas_opt 5,6,7,8
   - 0 (default): Sea-spray emissions from leads use the seas_opt source function weighted by the open ocean fraction (1-seaice_concentration)
   - 1: Sea-spray emissions from leads use the seas_opt source function weighted by the leads fraction, also applying a correction factor to reduce the emissions to account for the reduced wind fetch over leads (Lapere et al., 2024). Requires lead fraction input in the wrflowinp file in variable LEADFRAC
-### dms_opt (0, 1, previoulsy dmsemis_opt)
+### dms_opt (0, 1, 2, 3; previoulsy dmsemis_opt)
 This option controls the treatment of dimethyl sulfide (DMS) emissions from the surface ocean in the model. This replaces the old option dmsemis_opt (deprecated but can still be used if needed). Options 1, 2, and 3 require oceanic DMS concentration input in the wrflowinp file in variable DMS_OCEAN. DMS_OCEAN can be taken from the climatologies of [Lana 2011](https://doi.org/10.1029/2010GB003850), [Hulswar 2021](https://doi.org/10.5194/essd-14-2963-2022) or the CSIB model [(Hayashida et al., 2019)](https://doi.org/10.5194/gmd-12-1965-2019). For options 1, 2, and 3, emissions from sea ice regions are scaled by the open ocean fraction to the power of 0.4 (Loose et al., 2009).
   - 0 (default): No DMS emissions from the ocean surface.
   - 1 (recommended): DMS emissions using the Nightingale et al. (2000) sea-air flux parameterization.

--- a/polar-options.md
+++ b/polar-options.md
@@ -1,6 +1,6 @@
 # New namelist.input options in the polar version
 
-This file describes the new namelist.input options in the WRF-Chem-Polar version. 
+This file describes the new namelist.input options in the WRF-Chem-Polar version.
 
 *Many of these options are not specific to polar regions and can be used for modeling outside the poles.  The main polar specific developments are related to sea ice, which shoudl not negatively impact the results outside the polar regions.*
 
@@ -26,9 +26,11 @@ This option controls the sea-spray emissions from sea ice leads. Only compatible
   - 0 (default): Sea-spray emissions from leads use the seas_opt source function weighted by the open ocean fraction (1-seaice_concentration)
   - 1: Sea-spray emissions from leads use the seas_opt source function weighted by the leads fraction, also applying a correction factor to reduce the emissions to account for the reduced wind fetch over leads (Lapere et al., 2024). Requires lead fraction input in the wrflowinp file in variable LEADFRAC
 ### dms_opt (0, 1, previoulsy dmsemis_opt)
-This option controls the treatment of dimethyl sulfide (DMS) emissions from the surface ocean in the model. This replaces the old option dmsemis_opt (deprecated but can still be used if needed).
+This option controls the treatment of dimethyl sulfide (DMS) emissions from the surface ocean in the model. This replaces the old option dmsemis_opt (deprecated but can still be used if needed). Options 1, 2, and 3 require oceanic DMS concentration input in the wrflowinp file in variable DMS_OCEAN. DMS_OCEAN can be taken from the climatologies of [Lana 2011](https://doi.org/10.1029/2010GB003850), [Hulswar 2021](https://doi.org/10.5194/essd-14-2963-2022) or the CSIB model [(Hayashida et al., 2019)](https://doi.org/10.5194/gmd-12-1965-2019). For options 1, 2, and 3, emissions from sea ice regions are scaled by the open ocean fraction to the power of 0.4 (Loose et al., 2009).
   - 0 (default): No DMS emissions from the ocean surface.
-  - 1 (recommended): DMS emissions from the surface ocean are activated for the open ocean grid cell fraction, using the Nightingale et al. (2000) air–sea flux parameterization. In sea ice, emissions are scaled by the open ocean fraction to the power of 0.4 (Loose et al., 2009). Requires oceanic DMS concentration input in the wrflowinp file in variable DMS_OCEAN. DMS_OCEAN can be taken from the climatologies of [Lana 2011](https://doi.org/10.1029/2010GB003850), [Hulswar 2021](https://doi.org/10.5194/essd-14-2963-2022) or the CSIB model [(Hayashida et al., 2019)](https://doi.org/10.5194/gmd-12-1965-2019).
+  - 1 (recommended): DMS emissions using the Nightingale et al. (2000) sea-air flux parameterization.
+  - 2: DMS emissions using the Liss and Merlivat (1986) sea-air flux parameterization.
+  - 3: DMS emissions using the Wanninkhof (2014) sea-air flux parameterization.
 ### blowing_snow_opt (0, 1): This option controls the emissions from blowing snow.
   - 0 (default): Disables emissions associated with blowing snow
   - 1: Includes sea salt aerosol emissions from blowing snow (on the main, halogen and mercury branches) and bromine emissions from blowing snow (halogens and mercury branches)


### PR DESCRIPTION
In the DMS emission module, add 2 new emission options, dms_emis = 2 and 3,
using the formulations of Liss and Merlivat (1986) and Wanninkhof (2014).
Also updates the module:
- Puts the exchange coefficient and Schmidt number parameterizations in subroutines
- Implements the flux dependence on DMS air concentrations
- Includes e_dms_ocean, the accumulated DMS emission flux, in the WRF output
- Improves comments and references
This partially addresses issue #94