### PR TITLE
Move optical code warnings to debug output

### DIFF
--- a/chem/module_optical_averaging.F
+++ b/chem/module_optical_averaging.F
@@ -4699,19 +4699,23 @@ END subroutine optical_prep_modal_soa_vbs
 ! check for refr and refi outside of lookup table range to prevent unstable extrapolation 'binterp' below
           if (refr < refrtabsw(1,ns)) then
              refr = refrtabsw(1,ns)
-             write(*,*), 'Warning: refr is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             write(msg, *) 'Warning: refr is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refr > refrtabsw(prefr,ns)) then
              refr = refrtabsw(prefr,ns)
-             write(*,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at SW band ', ns
+             write(msg,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at SW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refi < refitabsw(1,ns)) then
              refi = refitabsw(1,ns)
-             write(*,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             write(msg,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at SW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refi > refitabsw(prefi,ns)) then
              refi = refitabsw(prefi,ns)
-             write(*,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at SW band ', ns
+             write(msg,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at SW band ', ns
+             CALL wrf_debug(100, msg)
           endif
 
 ! interpolate coefficients linear in refractive index
@@ -4974,19 +4978,23 @@ END subroutine optical_prep_modal_soa_vbs
 ! check for refr and refi outside of lookup table range to prevent unstable extrapolation 'binterp' below
           if (refr < refrtablw(1,ns)) then
              refr = refrtablw(1,ns)
-             write(*,*), 'Warning: refr is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             write(msg,*), 'Warning: refr is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refr > refrtablw(prefr,ns)) then
              refr = refrtablw(prefr,ns)
-             write(*,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at LW band ', ns
+             write(msg,*), 'Warning: refr is larger than lookup table range and reset to maximum bound at LW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refi < refitablw(1,ns)) then    
              refi = refitablw(1,ns)
-             write(*,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             write(msg,*), 'Warning: refi is smaller than lookup table range and reset to minimum bound at LW band ', ns
+             CALL wrf_debug(100, msg)
           endif
           if (refi > refitablw(prefi,ns)) then
              refi = refitablw(prefi,ns)
-             write(*,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at LW band ', ns
+             write(msg,*), 'Warning: refi is larger than lookup table range and reset to maximum bound at LW band ', ns
+             CALL wrf_debug(100, msg)
           endif
 
 ! interpolate coefficients linear in refractive index


### PR DESCRIPTION
In chem/module_optical_averaging.F, replace the WRITE statements by
calls to wrf_debug for the warning messages for the interpolation of
refractive indices, to avoid a very large volume of output in situations
when aerosol concentrations are very low.