### PR TITLE
Add a PBAP emission module

### DIFF
--- a/Registry/registry.chem
+++ b/Registry/registry.chem
@@ -616,6 +616,8 @@ state    real  wdflx          ijo     misc        1         Z      r       "WET_
 state    real  e_nacl_ocean   ij      misc        1         Z      rh      "E_NACL_OCEAN"       "Ocean NaCl emiss"               "ug m^-2"
 state    real  e_nacl_blow    ij      misc        1         Z      rh      "E_NACL_BLOW"        "Blowing snow NaCl emiss"        "ug m^-2"
 state    real  e_nacl_leads    ij      misc        1         Z      rh      "E_NACL_LEADS"        "Leads NaCl emiss"        "ug m^-2"
+state    real  e_bact         ij      misc        1         Z      rh      "E_BACT"             "Bacteria aerosol emiss"         "mg m^-2"
+state    real  e_spore        ij      misc        1         Z      rh      "E_SPORE"            "Spore aerosol emiss"            "mg m^-2"
 
 #
 state    real  e_bio          ijo     misc        1         Z      r        "E_BIO"             "EMISSIONS"             "ppm m/min"
@@ -3943,6 +3945,7 @@ rconfig   integer     blowing_snow_opt    namelist,chem          1              
 rconfig   integer     seas_leads_opt      namelist,chem          max_domains    0 	rh    "seas_leads_opt"      ""      ""
 rconfig   integer     seas_so4_opt        namelist,chem          max_domains    0       rh    "seas_so4_opt"        ""      ""
 rconfig   integer     seas_oa_opt         namelist,chem          max_domains    0       rh    "seas_oa_opt"         ""      ""
+rconfig   integer     pbap_opt            namelist,chem          1              0       rh    "pbap_opt"            ""      ""
 rconfig   integer     nuc_sulf_opt        namelist,chem          max_domains    2       rh    "nuc_sulf_opt"         ""      ""
 rconfig   integer     nuc_msa_opt         namelist,chem          max_domains    0       rh    "nuc_msa_opt"         ""      ""
 rconfig   real        nuc_msa_fac         namelist,chem          max_domains    1.0     rh    "nuc_msa_fac"         ""      ""

--- a/chem/Makefile
+++ b/chem/Makefile
@@ -92,6 +92,7 @@ MODULES =                                 \
         module_data_uoc_wd.o              \
         module_seaspray_emis.o            \
         module_dms_emis.o                 \
+        module_pbap_emis.o                \
         module_blowing_snow_emis.o        \
         module_mosaic_addemiss.o          \
         module_mosaic_initmixrats.o       \

--- a/chem/chem_driver.F
+++ b/chem/chem_driver.F
@@ -925,7 +925,9 @@
               grid%mebio_isop,grid%mebio_apin,grid%mebio_bpin, grid%mebio_bcar,            &
               grid%mebio_acet,grid%mebio_mbo,grid%mebio_no,                                &
               current_month,                                                               &
+              grid%lai, &
               grid%lakemask,grid%e_nacl_ocean,grid%e_nacl_blow,grid%e_nacl_leads,          &
+              grid%e_bact, grid%e_spore, &
          ! stuff for LNOx emissions
              grid%ht, grid%refl_10cm, grid%ic_flashrate, grid%cg_flashrate,                 &
          ! stuff for aircraft emissions

--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -77,6 +77,7 @@
    USE module_model_constants, only:t0
    USE module_seaspray_emis, only:seaspray_emis_init
    USE module_blowing_snow_emis, only:blowing_snow_emis_init
+   USE module_pbap_emis, only:pbap_emis_init
 
    IMPLICIT NONE
 
@@ -568,6 +569,17 @@ call wrf_message("**************************************************************
        CALL wrf_error_fatal ('chemics_init: error, blowing snow emission &
            blowing_snow_opt is only compatible with GOCART, MOSAIC_4BIN &
            and MOSAIC_8BIN.')
+     ENDIF
+   ENDIF
+   !-- Checks for continental PBAP aerosol emissions option
+   IF ( config_flags%pbap_opt > 0 ) THEN
+     IF(aer_is_gocart) THEN
+       ! Initialize continental PBAP aerosol emissions
+       CALL wrf_debug( 15, 'Calling pbap_emis_init')
+       CALL pbap_emis_init(config_flags%chem_opt)
+     ELSE
+       CALL wrf_error_fatal ('chemics_init: error, PBAP emission &
+           pbap_opt is only compatible with GOCART')
      ENDIF
    ENDIF
 

--- a/chem/depend.chem
+++ b/chem/depend.chem
@@ -83,6 +83,8 @@ module_seaspray_emis.o:
 
 module_blowing_snow_emis.o:
 
+module_pbap_emis.o: module_data_gocartchem.o
+
 module_dms_emis.o:
 
 module_data_cbmz.o: module_peg_util.o
@@ -345,7 +347,7 @@ module_aer_drydep_simple.o:
 
 module_interpolate.o:
 
-chemics_init.o: module_cbm4_initmixrats.o module_cbmz_initmixrats.o module_gocart_aerosols.o ../phys/module_data_gocart_dust.o module_data_gocart_seas.o module_data_gocartchem.o module_gocart_chem.o module_dep_simple.o module_ftuv_driver.o module_phot_mad.o module_gocart_chem.o module_aerosols_sorgam.o module_aerosols_soa_vbs.o module_aerosols_soa_vbs_het.o module_mixactivate_wrappers.o module_mosaic_driver.o module_input_chem_data.o module_cam_mam_init.o module_cam_mam_wetscav.o module_prep_wetscav_sorgam.o module_aerosols_sorgam_vbs.o module_phot_tuv.o ../share/module_HLaw.o module_ctrans_grell.o module_mozcart_wetscav.o ../share/module_chem_share.o module_seaspray_emis.o module_blowing_snow_emis.o module_aer_drydep_simple.o
+chemics_init.o: module_cbm4_initmixrats.o module_cbmz_initmixrats.o module_gocart_aerosols.o ../phys/module_data_gocart_dust.o module_data_gocart_seas.o module_data_gocartchem.o module_gocart_chem.o module_dep_simple.o module_ftuv_driver.o module_phot_mad.o module_gocart_chem.o module_aerosols_sorgam.o module_aerosols_soa_vbs.o module_aerosols_soa_vbs_het.o module_mixactivate_wrappers.o module_mosaic_driver.o module_input_chem_data.o module_cam_mam_init.o module_cam_mam_wetscav.o module_prep_wetscav_sorgam.o module_aerosols_sorgam_vbs.o module_phot_tuv.o ../share/module_HLaw.o module_ctrans_grell.o module_mozcart_wetscav.o ../share/module_chem_share.o module_seaspray_emis.o module_blowing_snow_emis.o module_aer_drydep_simple.o  module_pbap_emis.o
 
 module_tropopause.o: module_interpolate.o
 
@@ -367,7 +369,7 @@ mechanism_driver.o: module_data_radm2.o module_radm.o module_aerosols_sorgam.o m
 
 optical_driver.o: module_optical_averaging.o module_peg_util.o module_data_mosaic_therm.o
 
-emissions_driver.o: module_add_emiss_burn.o module_data_radm2.o module_radm.o module_bioemi_simple.o module_bioemi_beis314.o module_bioemi_megan2.o module_emissions_anthropogenics.o module_cbmz_addemiss.o module_cb05_addemiss.o module_mosaic_addemiss.o module_aerosols_sorgam.o module_aerosols_soa_vbs.o module_aerosols_soa_vbs_het.o module_aerosols_sorgam_vbs.o module_plumerise1.o module_gocart_dust.o module_gocart_dust_afwa.o module_uoc_dust.o module_gocart_seasalt.o module_ghg_fluxes.o module_lightning_nox_driver.o module_cam_mam_addemiss.o module_dms_emis.o module_seaspray_emis.o module_blowing_snow_emis.o
+emissions_driver.o: module_add_emiss_burn.o module_data_radm2.o module_radm.o module_bioemi_simple.o module_bioemi_beis314.o module_bioemi_megan2.o module_emissions_anthropogenics.o module_cbmz_addemiss.o module_cb05_addemiss.o module_mosaic_addemiss.o module_aerosols_sorgam.o module_aerosols_soa_vbs.o module_aerosols_soa_vbs_het.o module_aerosols_sorgam_vbs.o module_plumerise1.o module_gocart_dust.o module_gocart_dust_afwa.o module_uoc_dust.o module_gocart_seasalt.o module_ghg_fluxes.o module_lightning_nox_driver.o module_cam_mam_addemiss.o module_dms_emis.o module_seaspray_emis.o module_blowing_snow_emis.o  module_pbap_emis.o
 
 dry_dep_driver.o: module_data_radm2.o module_aer_drydep.o module_dep_simple.o module_aerosols_sorgam.o module_aerosols_soa_vbs.o module_aerosols_soa_vbs.o module_aerosols_sorgam_vbs.o module_mosaic_drydep.o module_mixactivate_wrappers.o ../phys/module_mixactivate.o module_cam_mam_drydep.o ../phys/module_data_cam_mam_asect.o ../phys/module_data_cam_mam_aero.o ../phys/module_cam_support.o module_data_mosaic_asect.o module_aer_drydep_simple.o
 

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -64,7 +64,9 @@ CONTAINS
          mebio_isop, mebio_apin, mebio_bpin, mebio_bcar,                   &
          mebio_acet, mebio_mbo, mebio_no,                                  &
          current_month,                                                    &
+         lai, &
          lakemask, e_nacl_ocean, e_nacl_blow, e_nacl_leads,                &
+         e_bact,  e_spore, &
          ! end stuff for MEGAN v2.04
          ! stuff for LNOx emissions
          ht, refl_10cm,                                                    &
@@ -104,6 +106,7 @@ CONTAINS
   USE module_seaspray_emis, only: seaspray_emis
   USE module_dms_emis, only: dms_emis
   USE module_blowing_snow_emis, only: blowing_snow_emis
+  USE module_pbap_emis, only: pbap_emis
   USE uoc_dust  
   USE module_gocart_dms_emis, only: gocart_dmsemis
   USE module_mosaic_addemiss
@@ -330,7 +333,9 @@ CONTAINS
            adapt_step_flag
 
       REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: lakemask
-      REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_nacl_ocean, e_nacl_blow, e_nacl_leads
+      REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: lai
+      REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_nacl_ocean, &
+                                   e_nacl_blow, e_nacl_leads, e_spore, e_bact
 
 !     stuff for aircraft emissions
 
@@ -815,6 +820,19 @@ real, save :: freq_industry(24)    = &
          ids,ide, jds,jde, kds,kde,                                    &
          ims,ime, jms,jme, kms,kme,                                    &
          its,ite, jts,jte, kts,kte)
+      ENDIF
+
+      ! Primay biological aerosol particles (PBAP) emissions
+      IF(config_flags%pbap_opt > 0) THEN
+        ! PBAP emissions for GOCART aerosols
+        CALL wrf_debug(15, 'PBAP emissions')
+        CALL pbap_emis( id, dtstep, dz8w, &
+         config_flags%chem_opt, config_flags%pbap_opt, &
+         rho_phy, chem, e_bact, e_spore,                    &
+         xland, ivgtyp, xice, snowh, lai, T2, Q2, &
+         ids,ide, jds,jde, kds,kde,                                 &
+         ims,ime, jms,jme, kms,kme,                                 &
+         its,ite, jts,jte, kts,kte                                  )
       ENDIF
 
       dust_select:  SELECT CASE(config_flags%dust_opt)

--- a/chem/emissions_driver.F
+++ b/chem/emissions_driver.F
@@ -822,7 +822,7 @@ real, save :: freq_industry(24)    = &
          its,ite, jts,jte, kts,kte)
       ENDIF
 
-      ! Primay biological aerosol particles (PBAP) emissions
+      ! Primary biological aerosol particles (PBAP) emissions
       IF(config_flags%pbap_opt > 0) THEN
         ! PBAP emissions for GOCART aerosols
         CALL wrf_debug(15, 'PBAP emissions')

--- a/chem/module_pbap_emis.F
+++ b/chem/module_pbap_emis.F
@@ -1,4 +1,4 @@
-! Louis Marelle 2025/07
+! Louis Marelle, Anderson Da Silva, 2025
 !
 ! Purpose:
 !  Compute primary biological aerosol particle (PBAP) emissions from
@@ -6,15 +6,19 @@
 !
 ! Remarks:
 !  - Pollen not yet included
-!  - Only enabled for MODIS. To enable for USGS too, need to define bactflux_from_usgs_land
+!  - Only enabled for MODIS landuse. To enable for USGS too, need to define
+!    bactflux_from_usgs_land
 !  - Could add separate tracers bact1 and spore1 for bacteria and spores
 !  - Could emit to MOSAIC tracers oc_a
 !
 ! References
 ! ==============================================================================
-!  (1) Chatziparaschos et al. (2024) - https://doi.org/10.5194/egusphere-2024-952
-!  (2) Hummel et al. (2015) - https://doi.org/10.5194/acp-15-6127-2015
-!  (3) Burrows et al. (2009) - https://doi.org/10.5194/acp-9-9281-2009
+!  (1) Da Silva, A., Marelle, L., Lapere, R., and Raut, J.-C. Modelling Ice
+!      Nucleating Particles from High-Latitude Sources to Reproduce Arctic In
+!      Situ Concentrations. In preparation, 2026
+!  (2) Chatziparaschos et al. (2024) - https://doi.org/10.5194/egusphere-2024-952
+!  (3) Hummel et al. (2015) - https://doi.org/10.5194/acp-15-6127-2015
+!  (4) Burrows et al. (2009) - https://doi.org/10.5194/acp-9-9281-2009
 
 MODULE module_pbap_emis
 
@@ -190,7 +194,7 @@ MODULE module_pbap_emis
           ! emission flux (ug m-2 s-1)
           ! 1E-9 for kg m-3 to ug um-3 conversion
           ! Bacteria
-          bact_vol_emiss = bact_num_emiss * (piconst/6.0)*AER_DIAM_BACT**3.0
+          bact_vol_emiss = bact_num_emiss * (PICONST/6.0)*AER_DIAM_BACT**3.0
           bact_mass_emiss = bact_vol_emiss * BACT_AER_DENS * 1.0E-9
           bact_mass_emiss = MAX(bact_mass_emiss, 0.0)
           e_bact(i,j) = e_bact(i,j) + bact_mass_emiss*1.E-3*dtstep
@@ -269,10 +273,10 @@ MODULE module_pbap_emis
     CALL nl_get_mminlu( 1, mminlu_loc )
     IF(TRIM(mminlu_loc) == 'MODIS' &
        .OR. TRIM(mminlu_loc) == 'MODIFIED_IGBP_MODIS_NOAH') THEN
-      CALL wrf_debug(15, 'drydep_simple_init: Using the following land cover type:')
+      CALL wrf_debug(15, 'pbap_emis_init: Using the following land cover type:')
       CALL wrf_debug(15, TRIM(mminlu_loc))
     ELSE
-      CALL wrf_error_fatal('drydep_simple_init: land cover type not supported')
+      CALL wrf_error_fatal('pabap_emis_init: land cover type not supported')
     END IF
 
   END SUBROUTINE pbap_emis_init

--- a/chem/module_pbap_emis.F
+++ b/chem/module_pbap_emis.F
@@ -1,0 +1,281 @@
+! Louis Marelle 2025/07
+!
+! Purpose:
+!  Compute primary biological aerosol particle (PBAP) emissions from
+!  continental sources
+!
+! Remarks:
+!  - Pollen not yet included
+!  - Only enabled for MODIS. To enable for USGS too, need to define bactflux_from_usgs_land
+!  - Could add separate tracers bact1 and spore1 for bacteria and spores
+!  - Could emit to MOSAIC tracers oc_a
+!
+! References
+! ==============================================================================
+!  (1) Chatziparaschos et al. (2024) - https://doi.org/10.5194/egusphere-2024-952
+!  (2) Hummel et al. (2015) - https://doi.org/10.5194/acp-15-6127-2015
+!  (3) Burrows et al. (2009) - https://doi.org/10.5194/acp-9-9281-2009
+
+MODULE module_pbap_emis
+
+  IMPLICIT NONE
+
+  !---- Global module-wide variables
+  ! chem_opt aerosol model family
+  LOGICAL :: aer_is_gocart
+  LOGICAL :: aer_is_mosaic4bin
+  LOGICAL :: aer_is_mosaic8bin
+  ! Land cover type name
+  CHARACTER*256 :: mminlu_loc
+
+  ! Maps MODIS surface categories to Burrows2009 categories for bacterial
+  ! number emissions (m-2 s-1)
+  ! https://acp.copernicus.org/articles/9/9281/2009/
+  REAL, SAVE :: bactflux_from_modis_land(21)
+  DATA bactflux_from_modis_land / &
+    ! Burrows2009 bact flux      <---- MODIS category
+    0., &! forest                   1 'Evergreen Needleleaf Forest'
+    0., &! forest                   2 'Evergreen Broadleaf Forest'
+    0., &! forest                   3 'Deciduous Needleleaf Forest'
+    0., &! forest                   4 'Deciduous Broadleaf Forest'
+    0., &! forest                   5 'Mixed Forests'
+  502., &! shrubs                   6 'Closed Shrublands'
+  502., &! shrubs                   7 'Open Shrublands'
+  648., &! grasslands               8 'Woody Savannas'
+  648., &! grasslands               9 'Savannas'
+  648., &! grasslands              10 'Grasslands'
+  196., &! wetlands                11 'Permanent wetlands'
+  704., &! crops                   12 'Croplands'
+    0., &! unassigned              13 'Urban and Built-Up'
+  704., &! crops                   14 'cropland/natural vegetation mosaic'
+   7.7, &! landice                 15 'Snow and Ice'
+    0., &! deserts                 16 'Barren or Sparsely Vegetated'
+    0., &! seas                    17 'Water'
+    0., &! tundra                  18 'Wooded Tundra'
+    0., &! tundra                  19 'Mixed Tundra'
+    0., &! deserts                 20 'Barren Tundra'
+    0./  ! unassigned              21 'Lakes'
+
+
+  CONTAINS
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE pbap_emis( id, dtstep, dz8w, &
+         chem_opt, pbap_opt, &
+         rho_phy, chem, e_bact, e_spore,                            &
+         xland, ivgtyp, xice, snowh, lai, t2, q2, &
+         ids,ide, jds,jde, kds,kde,                                 &
+         ims,ime, jms,jme, kms,kme,                                 &
+         its,ite, jts,jte, kts,kte                                  )
+
+    ! Purpose:
+    !  Calculate Primary Biological Aerosol Particles (PBAP) emissions from
+    !  bacteria and fungal spores
+
+    ! Arguments:
+    ! Input:
+    !  id = domain ID number
+    !  dtstep = model time step (s)
+    !  dz8w = 3D vertical level depth (m)
+    !  chem_opt = chemical mechanism + aerosol mechanism option from config_flags
+    !  pbap_opt = pbap emission option from config_flags
+    !  rho_phy = 3D air density (kg m-3)
+    !  xland = landmask flag (1 land, 2 water)
+    !  ivgtyp = land cover category (int category)
+    !  xice = sea ice or lake ice fraction (0-1)
+    !  snowh = snow height (m)
+    !  lai = leaf aera index (m2 m-2)
+    !  t2 = 2-m temperature (K)
+    !  q2 = 2-m specific humidity (kg kg-1)
+    !  ids,ims,its etc. = domain, memory, and tile start and end indices
+    ! Input/output
+    !  chem = advected chemical species (gases in ppm, aerosols in ug kg-1)
+    !  e_bact = accumulated bacteria emission flux (mg m-2)
+    !  e_spore = accumulated spore emission flux (mg m-2)
+
+    !TODO Should include all explicit ONLY: associations for module_state_description
+    USE module_state_description, ONLY: NUM_CHEM, P_OC1, PARAM_FIRST_SCALAR
+    USE module_model_constants, ONLY: PICONST
+    USE module_data_gocartchem, only: OC_MFAC
+
+    IMPLICIT NONE
+
+    !---- Arguments
+    ! Input
+    INTEGER, INTENT(IN) :: chem_opt, pbap_opt
+    INTEGER, INTENT(IN) :: id,                                      &
+                           ids,ide, jds,jde, kds,kde,               &
+                           ims,ime, jms,jme, kms,kme,               &
+                           its,ite, jts,jte, kts,kte
+    INTEGER, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: ivgtyp
+    REAL, INTENT(IN) :: dtstep
+    REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(IN) :: dz8w, rho_phy
+    REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: xland
+    REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN) :: xice, snowh, lai, t2, q2
+    ! Input/output
+    REAL, DIMENSION(ims:ime, kms:kme, jms:jme, NUM_CHEM), INTENT(INOUT) :: chem
+    REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT) :: e_bact, e_spore
+
+    !---- Local variables
+    ! PBAP emission fluxes (ug m-2 s-1, um3 m-2 s-1, m-2 s-1)
+    REAL :: bact_mass_emiss, bact_vol_emiss, bact_num_emiss
+    REAL :: spore_mass_emiss, spore_vol_emiss, spore_num_emiss
+    ! PBAP active sites density (#/m²)
+    REAL :: inas_dens_bact, inas_dens_spore
+    ! aerosols area (m²)
+    REAL :: aersurf_spore, aersurf_bact
+    ! Conversion factor from 1/m2/s to 1/kg_dry_air
+    REAL :: conv
+    ! Air density (kg/m3)
+    REAL :: air_dens
+    ! Indices
+    INTEGER :: i, j
+
+    !---- Parameters
+    ! Aerosol diameter (um)
+    REAL, PARAMETER :: AER_DIAM_BACT = 1.0
+    REAL, PARAMETER :: AER_DIAM_SPORE = 3.0
+    ! Aerosol density (kg m-3)
+    REAL, PARAMETER :: BACT_AER_DENS = 1.0E3
+    REAL, PARAMETER :: SPORE_AER_DENS = 1.0E3
+    ! Parameters for the Hummel et al. (2015) fungal spore emission
+    ! parameterization
+    REAL, PARAMETER :: B1_HUMMEL15 = 20.426
+    REAL, PARAMETER :: B2_HUMMEL15 = 3.93E4
+
+    !-------- Compute pbap emissions --------
+    DO i=its,ite
+      DO j=jts,jte
+
+        ! Only perform pbap emissions over land. Sea ice is considered land,
+        ! so exclude sea ice points explicitly.
+        IF (xland(i,j)<1.5 .AND. xice(i,j)<=0.01) THEN
+          !-------- Initialize PBAP emission parameters
+          bact_num_emiss = 0.0
+          bact_vol_emiss = 0.0
+          bact_mass_emiss = 0.0
+          spore_num_emiss = 0.0
+          spore_vol_emiss = 0.0
+          spore_mass_emiss = 0.0
+          air_dens = rho_phy(i,kts,j)
+          ! Conversion factor from m-2 s-1 to kg_dry_air-1
+          conv = 1.0/(rho_phy(i,kts,j) * dz8w(i,kts,j)) * dtstep
+
+          !-------- Compute the bacterial aerosol number emission flux
+          IF(pbap_opt > 0 &
+             .AND. (TRIM(mminlu_loc) == 'MODIS' &
+             .OR. TRIM(mminlu_loc) == 'MODIFIED_IGBP_MODIS_NOAH') ) THEN
+            ! Bacterial flux from Burrows2009
+            bact_num_emiss = bactflux_from_modis_land(ivgtyp(i,j))
+            IF(snowh(i,j) > 0.1) THEN
+              bact_num_emiss = 7.7 ! m-2 s-1, value for land ice in Burrows2009
+            ENDIF
+          ELSE
+            bact_num_emiss = 0.
+          ENDIF
+
+          !-------- Compute the spore aerosol number emission flux
+          IF(pbap_opt > 0) THEN
+            ! Spore flux from Hummel2015
+            spore_num_emiss = B1_HUMMEL15*(t2(i,j)-275.82) + B2_HUMMEL15*q2(i,j)*lai(i,j)
+            IF(snowh(i,j) > 0.1) THEN
+              spore_num_emiss = 0.
+            ENDIF
+          ELSE
+            spore_num_emiss = 0.
+          ENDIF
+
+          !---- Convert PBAP aerosol number emission flux (m-2 s-1) to mass
+          ! emission flux (ug m-2 s-1)
+          ! 1E-9 for kg m-3 to ug um-3 conversion
+          ! Bacteria
+          bact_vol_emiss = bact_num_emiss * (piconst/6.0)*AER_DIAM_BACT**3.0
+          bact_mass_emiss = bact_vol_emiss * BACT_AER_DENS * 1.0E-9
+          bact_mass_emiss = MAX(bact_mass_emiss, 0.0)
+          e_bact(i,j) = e_bact(i,j) + bact_mass_emiss*1.E-3*dtstep
+          ! Fungal spores
+          spore_vol_emiss = spore_num_emiss * (PICONST/6.0)*AER_DIAM_SPORE**3.0
+          spore_mass_emiss = spore_vol_emiss * SPORE_AER_DENS * 1.0E-9
+          spore_mass_emiss = MAX(spore_mass_emiss, 0.0)
+          e_spore(i,j) = e_spore(i,j) + spore_mass_emiss*1.E-3*dtstep
+
+          !-------- Emit PBAP emissions to chem(i,k,j,l)
+          !---- Emit GOCART aerosols to chem
+          IF(aer_is_gocart) THEN
+            ! GOCART bacteria aerosols
+            IF (P_OC1 >= PARAM_FIRST_SCALAR) THEN
+              chem(i,kts,j,P_OC1) = chem(i,kts,j,P_OC1) &
+                                     + bact_mass_emiss * conv / OC_MFAC
+            ENDIF
+            ! GOCART fungal spore aerosols
+            IF (P_OC1 >= PARAM_FIRST_SCALAR) THEN
+              chem(i,kts,j,P_OC1) = chem(i,kts,j,P_OC1) &
+                                     + spore_mass_emiss * conv / OC_MFAC
+            ENDIF
+          !---- Other chem_opt cases are not supported
+          ELSE
+            CALL wrf_error_fatal ('pbap_emis: chem_opt not supported')
+          ENDIF ! aer_is_
+
+        END IF ! xland
+      END DO ! j
+    END DO ! i
+
+  END SUBROUTINE pbap_emis
+
+!------------------------------------------------------------------------------
+
+  SUBROUTINE pbap_emis_init(chem_opt)
+
+    ! Purpose:
+    !  Initialize the parameters for the PBAP aerosol emissions
+    !  in pbap_emis, which depend on chem_opt
+
+    USE module_state_description ! For chem_opt option values
+
+    IMPLICIT NONE
+
+    ! Arguments:
+    !  Input
+    INTEGER, INTENT(IN) :: chem_opt
+
+    !---- Initialize chem mechanism families IDs
+    aer_is_gocart = chem_opt == MOZCART_KPP .OR. &
+                    chem_opt == T1_MOZCART_KPP .OR. &
+                    chem_opt == GOCART_SIMPLE .OR. &
+                    chem_opt == GOCARTRADM2 .OR. &
+                    chem_opt == GOCARTRACM_KPP
+
+    aer_is_mosaic4bin = chem_opt == CBMZ_MOSAIC_4BIN .OR. &
+                        chem_opt == CBMZ_MOSAIC_DMS_4BIN .OR. &
+                        chem_opt == CBMZ_MOSAIC_4BIN_AQ .OR. &
+                        chem_opt == CBMZ_MOSAIC_DMS_4BIN_AQ .OR. &
+                        chem_opt == MOZART_MOSAIC_4BIN_KPP .OR. &
+                        chem_opt == MOZART_MOSAIC_4BIN_AQ_KPP .OR. &
+                        chem_opt == MOZART_MOSAIC_4BIN_DMS_AQ_KPP .OR. &
+                        chem_opt == CRI_MOSAIC_4BIN_AQ_KPP .OR. &
+                        chem_opt == SAPRC99_MOSAIC_4BIN_VBS2_KPP
+
+    aer_is_mosaic8bin = chem_opt == CBMZ_MOSAIC_8BIN .OR. &
+                        chem_opt == CBMZ_MOSAIC_DMS_8BIN .OR. &
+                        chem_opt == CBMZ_MOSAIC_8BIN_AQ .OR. &
+                        chem_opt == CBMZ_MOSAIC_DMS_8BIN_AQ .OR. &
+                        chem_opt == CRI_MOSAIC_8BIN_AQ_KPP .OR. &
+                        chem_opt == SAPRC99_MOSAIC_8BIN_VBS2_AQ_KPP .OR. &
+                        chem_opt == SAPRC99_MOSAIC_8BIN_VBS2_KPP
+
+    !-------- Initialize land cover type --------
+    CALL nl_get_mminlu( 1, mminlu_loc )
+    IF(TRIM(mminlu_loc) == 'MODIS' &
+       .OR. TRIM(mminlu_loc) == 'MODIFIED_IGBP_MODIS_NOAH') THEN
+      CALL wrf_debug(15, 'drydep_simple_init: Using the following land cover type:')
+      CALL wrf_debug(15, TRIM(mminlu_loc))
+    ELSE
+      CALL wrf_error_fatal('drydep_simple_init: land cover type not supported')
+    END IF
+
+  END SUBROUTINE pbap_emis_init
+
+END MODULE module_pbap_emis
+

--- a/polar-options.md
+++ b/polar-options.md
@@ -64,6 +64,10 @@ This option controls which scheme is used for the nucleation of sulfate aerosols
   - 0 (default): Disables halogen emissions and recycling from surface snow.
   - 1: Halogen emissions and recycling from surface snow, following Toyota et al. (2011).
 
+### pbap_opt (0, 1): This option controls Primary Biological Aerosol Particle (PBAP) emissions from land surfaces
+  - 0 (default): Disables PBAP emissions
+  - 1: Emissions of fungal spores and bacteria from land surfaces following Hummel et al. (2015) and Burrows et al. (2009) respectively. The option is only active for GOCART aerosols, and PBAP are emitted as OC1 (hydrophobic organic carbon).
+
 ## Aerosol-cloud interaction options
 ### aci_wrfchem_opt (0, 1, 2): This option controls the aerosol-cloud interactions for liquid droplets in WRF-Chem.
 This option only works with Thompson aerosol-aware microphysics, but not with other microphysics scheme.


### PR DESCRIPTION
Adds an emission module for continental Primary Biological Aerosol
Particles (PBAP), chem/module_pbap_emis.F
Emissions are controlled by namelist option pbap_opt in &chem
- pbap_opt = 1 enables bacterial emissions following Burrows et al. (2009)
  (works with MODIS land use only). It also enables fungal spore
  emissions, following Hummel et al. (2015).
PBAP emissions are only compatible with GOCART aerosols for now, and are
emitted to GOCART aerosol tracer OC1 (hydrophobic organic carbon).