### PR TITLE
Update parameters in aer_wetscav_simple

### DIFF
--- a/chem/chemics_init.F
+++ b/chem/chemics_init.F
@@ -412,6 +412,7 @@ call wrf_message("**************************************************************
        endif
      endif
    endif
+
    ! Simple aerosol wet scavenging for GOCART aerosols
    ! - Can be enabled for any GOCART chem_opt
    ! - For MOZCART mechanisms sulf scavenging needs to be
@@ -419,18 +420,17 @@ call wrf_message("**************************************************************
    ! - Can be enabled for other aerosol mechanisms if the proper mapping
    !   for chem_opt is provided in aer_wetscav_simple_init and if
    !   aerosol wetscav is not already done elsewhere for this chem_opt
+   ! - Can be enabled for other mp_physics option if evapprod, rainprod,
+   !   qlsink and precr, precs (+preci and precg ideally) are calculated
    IF (config_flags%wetscav_onoff == 1 .AND. aer_is_gocart) THEN
      IF(config_flags%mp_physics == THOMPSON &
         .OR. config_flags%mp_physics == THOMPSONAERO &
-        .OR. config_flags%mp_physics == WSM6SCHEME &
-        .OR. config_flags%mp_physics == CAMMGMPSCHEME &
         .OR. config_flags%mp_physics == MORR_TWO_MOMENT) THEN
        CALL wrf_debug( 15, 'Chemics_init: Calling aer_wetscav_simple_init' )
        CALL aer_wetscav_simple_init(config_flags%chem_opt)
      ELSE
        CALL wrf_error_fatal("ERROR: wet scavenging option for GOCART &
-            & requires mp_phys = THOMPSON, THOMPSONAERO, WSM6SCHEME, &
-            & CAMMGMPSCHEME or MORR_TWO_MOMENT")
+            & requires mp_phys = THOMPSON, THOMPSONAERO, or MORR_TWO_MOMENT")
      ENDIF
    ENDIF
 

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -720,8 +720,10 @@ CONTAINS
                            0.078E-6, 0.174E-6, 1.46E-6, 2.8E-6, 4.8E-6, &
                            9.0E-6, 16.0E-6 /)
       ! Fraction of activated aerosols for aer_pointers species
-      ! Activated fraction in liquid clouds - use values from Grell convection
-      ! wetscav
+      ! Activated fraction in liquid clouds
+      ! We use the same values as the aq_gas_ratio parameters for the same
+      ! species in the wetscav subroutine in convective clouds, in
+      ! phys/module_cu_gf_ctrans.F
       aq_aer_ratio(:) = (/ 1.0, 1.0, 1.0, 1.0, 1.0, &
                            0.8, 0.8, 0.5, 0.5, 0.5, &
                            0.5, 0.5 /)

--- a/chem/module_aer_wetscav_simple.F
+++ b/chem/module_aer_wetscav_simple.F
@@ -4,7 +4,8 @@
 ! - Perform wet scavenging of aerosols by grid scale rainout/washout
 !
 ! Remarks:
-! - Washout and rainout from Luo et al. (2019, 2020)
+! - Only compatible with Thompson and Morrison because they have the
+!   necessary output (3D precipitation, rainprod, evapprod, qlsink)
 !
 ! References:
 ! ==============================================================================
@@ -21,8 +22,8 @@
 MODULE module_aer_wetscav_simple
 
   IMPLICIT NONE
-  PRIVATE
 
+  PRIVATE
   PUBLIC :: aer_wetscav_simple, aer_wetscav_simple_init
 
   !---- Global module-wide variables
@@ -43,16 +44,36 @@ MODULE module_aer_wetscav_simple
 
   !---- Parameters
   ! Minimum values for performing wet scavenging:
-  ! Aerosol MMR (µg/kg), cloud/precip water MMR (µg/kg), cloud/precip fraction
+  ! Aerosol MMR (µg kg-1), cloud/precip water MMR (µg kg-1), cloud/precip fraction
   ! of cell area (0-1), loss fraction from wet scavenging process (0-1)
   REAL, PARAMETER :: AER_MINVAL = 1.0E-12, WATER_MINVAL = 1.0E-12, &
                      AERA_FRAC_MINVAL = 0.0001, LOSSFRAC_MINVAL = 1.0E-6
-  ! Scaling factor for resuspension rate, to take into account that
-  ! evaporation of hydrometeors can be incomplete. Value 0.5 from GEOS-CHEM
-  REAL, PARAMETER :: RESUSP_SCALING = 0.5
-  ! Flags for disabling in-cloud or below-cloud scavenging, or resuspension
-  LOGICAL, PARAMETER :: DO_RAINOUT = .true., DO_WASHOUT = .true., &
-                        DO_RESUSPENSION = .true.
+  ! Flag for disabling rainout ("in-cloud scavenging"), for tests
+  LOGICAL, PARAMETER :: DO_RAINOUT = .true.
+  ! Flag for disabling washout ("impaction", or "below-cloud scavenging"), for
+  ! tests
+  LOGICAL, PARAMETER :: DO_WASHOUT = .true.
+  ! Flag for disabling resuspension of aerosols from evaporating rain
+  ! LM - Disabled because this overestimates surface aerosol concentrations in
+  ! tests, especially during Arctic summer, without improving results
+  ! significantly in other conditions.
+  LOGICAL, PARAMETER :: DO_RESUSPENSION = .false.
+  ! Scaling factor for the resuspension rate, to take into account that
+  ! evaporation of hydrometeors can be incomplete.
+  ! LM - Luo2020 recommends 0.5, but tests show that this is way too large. If
+  ! resuspension needs to be included, use a much smaller value of 0.1
+  REAL, PARAMETER :: RESUSP_SCALING = 0.1
+  ! Flag for enabling rainout (in-cloud scavenging) from ice clouds
+  ! LM - Best to disable this for now, because:
+  ! 1 - INP activation is usually low, except near homogeneous freezing
+  !     temperatures
+  ! 2 - Using the same rainfrac for liquid and ice clouds as in Luo2020 biases
+  !     the results significantly in mixed-phase clouds (over-scavenging of
+  !     the liquid-borne aerosols when cloud ice is also converted to
+  !     precipitation).
+  ! This could be re-enabled if rainfrac_ice was calculated separately (based
+  ! on a "qisink" from the MP schemes, and a suitable ice_aer_ratio was found.
+  LOGICAL, PARAMETER :: DO_ICE_RAINOUT = .false.
 
   ! chem_opt aerosol model family
   LOGICAL :: aer_is_gocart
@@ -61,9 +82,9 @@ CONTAINS
 
 !----------------------------------------------------------------------------
 
-  SUBROUTINE aer_wetscav_simple( chem, qsrflx, dtstep, config_flags,  &
+  SUBROUTINE aer_wetscav_simple( chem, qsrflx, dtstep,                    &
                              t_phy, rho_phy, dz8w,                        &
-                             cldfra, rainprod, evapprod,                  &
+                             cldfra, rainprod, evapprod, qlsink,          &
                              precr, preci, precs, precg,                  &
                              qc, qi, qs, qr, qg,                          &
                              ids,ide, jds,jde, kds,kde,                   &
@@ -71,32 +92,32 @@ CONTAINS
                              its,ite, jts,jte, kts,kte                    )
 
   ! Purpose:
-  ! Calculates and removes wet scavenging tendencies for aerosols
+  !  Calculate and remove wet scavenging tendencies for aerosols
   !
   ! Arguments:
   ! Input:
   !   dtstep = model time step (s)
-  !   config_flags = namelist configuration flags
   !   t_phy = 3D physical temperature (K)
   !   dz8w = 3D vertical level depth (m)
-  !   rho_phy = 3D air density (kg/m3)
+  !   rho_phy = 3D air density (kg m-3)
   !   cldfra = 3D cloud fraction (unitless, 0-1)
-  !   rainprod = 3D rain production rate (kg/kg dry air/s)
-  !   evapprod = 3D rain evaporation rate (kg/kg dry air/s)
-  !   precr = 3D rain precipitation rate through grid cell (kg/m2/s)
-  !   preci = 3D ice precipitation rate through grid cell (kg/m2/s)
-  !   precs = 3D snow precipitation rate through grid cell (kg/m2/s)
-  !   precg = 3D graupel precipitation rate through grid cell (kg/m2/s)
-  !   qc = cloud water mixing ratio (kg/kg dry air)
-  !   qi = cloud ice mixing ratio (kg/kg dry air)
-  !   qs = snow water mixing ratio (kg/kg dry air)
-  !   qr = rain water mixing ratio (kg/kg dry air)
-  !   qg = graupel water mixing ratio (kg/kg dry air)
+  !   rainprod = 3D precipitation production rate (kg kg_dryair-1 s-1)
+  !   evapprod = 3D precipitation evaporation rate (kg kg_dry-1 s-1)
+  !   qlsink = 3D cloud water to precipitation conversion rate (s-1)
+  !   precr = 3D rain precipitation rate through grid cell (kg m-2 s-1)
+  !   preci = 3D ice precipitation rate through grid cell (kg m-2 s-1)
+  !   precs = 3D snow precipitation rate through grid cell (kg m-2 s-1)
+  !   precg = 3D graupel precipitation rate through grid cell (kg m-2 s-1)
+  !   qc = cloud water mixing ratio (kg kg_dryair-1)
+  !   qi = cloud ice mixing ratio (kg kg_dryair-1)
+  !   qs = snow water mixing ratio (kg kg_dryair-1)
+  !   qr = rain water mixing ratio (kg kg_dryair-1)
+  !   qg = graupel water mixing ratio (kg kg_dryair-1)
   !   ids,ims,its etc. = domain, memory, and tile start and end indices
   ! Input/output:
-  !   chem = advected chemical species (gases in ppm, aerosols in ug/kg)
+  !   chem = advected chemical species (gases in ppmv, aerosols in µg kg-1)
   ! Output:
-  !   qsrflx = aerosol column change due to scavenging (µg/m2)
+  !   qsrflx = aerosol column change due to scavenging (µg m-2)
 
   ! USE associations:
   USE module_configure, ONLY: param_first_scalar, num_chem, grid_config_rec_type
@@ -107,14 +128,13 @@ CONTAINS
   IMPLICIT NONE
 
   !---- Arguments
-  TYPE(grid_config_rec_type), INTENT(IN) :: config_flags
   INTEGER, INTENT(IN) :: ids,ide, jds,jde, kds,kde,    &
                          ims,ime, jms,jme, kms,kme,    &
                          its,ite, jts,jte, kts,kte
   REAL, INTENT(IN) :: dtstep
   REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN) :: t_phy, rho_phy, &
       dz8w, qi, qc, qs, qr, qg, rainprod, evapprod, precr, preci, precs, &
-      precg, cldfra
+      precg, cldfra, qlsink
   REAL, DIMENSION(ims:ime,kms:kme,jms:jme,num_chem), INTENT(INOUT) :: chem
   REAL, DIMENSION(ims:ime, jms:jme, num_chem),          &
         INTENT(OUT) :: qsrflx
@@ -137,8 +157,8 @@ CONTAINS
   REAL :: cloud_water, precip_water, liquid_fraction
   ! Rainout activation efficiency of species (0-1)
   REAL :: aq_aer_ratio_iaer, ice_aer_ratio_iaer
-  ! Total 3D precipitation trough cell for rain/snow/ice (kg/m2/hr), rain
-  ! production rate at i,k,j (kg/kg/s)
+  ! Total 3D precipitation trough cell for rain/snow/ice (kg m-2 hr-1), rain
+  ! production rate at i,k,j (kg kg-1 s-1)
   REAL :: ppr, pps, ppi, rainrate
   ! Temperature (K)
   REAL :: tk
@@ -146,6 +166,8 @@ CONTAINS
   REAL :: cloud_fraction
   ! Fraction of aerosol species washed out/rained out/resuspended (0-1)
   REAL :: washfrac, rainfrac, resusp_frac
+  ! Fraction of aerosol species rained out from liquid clouds (0-1)
+  REAL :: rainfrac_liq
   ! Efficiency of aerosol uptake in cloud water and cloud ice (0-1), for GOCART
   REAL :: cloud_uptk_effic_liq, cloud_uptk_effic_ice
   ! Conversion factor from /kg to /m2
@@ -159,6 +181,8 @@ CONTAINS
   REAL :: chem_spec_before
 
   !-------- Perform wet scavenging for aerosol species -------
+  ! Initialize deposition flux
+  qsrflx(:,:,:) = 0.
   IF(DO_RAINOUT .OR. DO_WASHOUT) THEN
   DO j=jts,jte
   DO i=its,ite
@@ -197,27 +221,46 @@ CONTAINS
       ppi = MAX(0., (preci(i,k,j) + precg(i,k,j)) * 3600.)
 
       !-- Calculate rainout parameters
-      ! frac_rainout is also needed to calculate frac_washout for washout
-      CALL calc_rainout_parameters( rainfrac, frac_rainout, &
-               cloud_uptk_effic_liq, cloud_uptk_effic_ice, &
-               tk, cloud_fraction, cloud_water, liquid_fraction, &
-               rainrate, dtstep)
-      rainfrac_1d(k) = rainfrac
-      cloud_uptk_effic_liq_1d(k) = cloud_uptk_effic_liq
-      cloud_uptk_effic_ice_1d(k) = cloud_uptk_effic_ice
+      ! Calculate rainfrac, the cloud water scavenging fraction from rainout,
+      ! and frac_rainout the fractional area of precipitating cloud at level
+      ! k, needed to calculate frac_washout, the fractional precipitation area
+      ! coverage in the grid cell
+      CALL calc_rainout_parameters(rainfrac=rainfrac, &
+               frac_rainout=frac_rainout, &
+               cloud_uptk_effic_liq=cloud_uptk_effic_liq, &
+               cloud_uptk_effic_ice=cloud_uptk_effic_ice, &
+               tk=tk, cloud_fraction=cloud_fraction, &
+               cloud_water=cloud_water, liquid_fraction=liquid_fraction, &
+               rainrate=rainrate, dtstep=dtstep)
+      ! Liquid water scavenging rate is also available directly from MP scheme
+      ! as qlsink
+      rainfrac_liq = MIN(1., qlsink(i,k,j)*dtstep)
+      IF(DO_ICE_RAINOUT) THEN
+        ! Include rainout from ice clouds
+        rainfrac_1d(k) = rainfrac
+        cloud_uptk_effic_liq_1d(k) = cloud_uptk_effic_liq
+        cloud_uptk_effic_ice_1d(k) = cloud_uptk_effic_ice
+      ELSE
+        ! Only consider rainout from liquid clouds
+        rainfrac_1d(k) = rainfrac_liq
+        cloud_uptk_effic_liq_1d(k) = cloud_uptk_effic_liq
+        cloud_uptk_effic_ice_1d(k) = 0.0
+      ENDIF
 
       !-- Calculate washout parameters
       ! The grid cell fraction experiencing washout, frac_washout, is the
-      ! max between frac_rainout at k and frac_washout at k+1 (this is why
-      ! we loop over k in descending order)
-      frac_washout = MIN(1.0, MAX(frac_washout, frac_rainout))
-      IF(DO_WASHOUT .AND. ppr+pps+ppi > 0.0 &
+      ! max between frac_rainout*cloud_fraction at k and frac_washout at k+1
+      ! (this is why we loop over k in descending order)
+      frac_washout = MIN(1.0, MAX(frac_washout, frac_rainout*cloud_fraction))
+      IF(DO_WASHOUT .AND. ppr+pps+ppi > 0. &
          .AND. frac_washout > AERA_FRAC_MINVAL) THEN
-        CALL washfrac_fine_aerosol(washfrac, ppr, pps, ppi, tk, &
-                                   frac_washout, dtstep)
+        ! Use different parameters for rain/snow/ice washout and fine/coarse
+        ! particles
+        CALL washfrac_fine_aerosol(washfrac=washfrac, ppr=ppr, pps=pps, &
+               ppi=ppi, tk=tk, frac_washout=frac_washout, dtstep=dtstep)
         washfrac_fine_1d(k) = washfrac
-        CALL washfrac_coarse_aerosol(washfrac, ppr, pps, ppi, tk, &
-                                     frac_washout, dtstep)
+        CALL washfrac_coarse_aerosol(washfrac=washfrac, ppr=ppr, pps=pps, &
+               ppi=ppi, tk=tk, frac_washout=frac_washout, dtstep=dtstep)
         washfrac_coarse_1d(k) = washfrac
       ENDIF ! DO_WASHOUT .AND. ...
 
@@ -274,7 +317,7 @@ CONTAINS
             !- GOCART: apply rainout
             IF(aer_is_gocart) THEN
               ! Remove GOCART mass
-              IF(p_chem > param_first_scalar) THEN
+              IF(p_chem >= param_first_scalar) THEN
                 cloudborne_frac = cloudborne_frac_liq+cloudborne_frac_ice
                 CALL remove_aer(aerconc=chem(i,k,j,p_chem), &
                                 dep_flux=deposition_flux(iaer), &
@@ -304,11 +347,11 @@ CONTAINS
           END IF
 
           !-- Apply washout to chem
-          IF(washfrac > 0.0) THEN
+          IF(washfrac > LOSSFRAC_MINVAL) THEN
             !- GOCART: apply washout
             IF(aer_is_gocart) THEN
               ! Remove GOCART mass
-              IF(p_chem > param_first_scalar) THEN
+              IF(p_chem >= param_first_scalar) THEN
                 CALL remove_aer(aerconc=chem(i,k,j,p_chem), &
                                 dep_flux=deposition_flux(iaer), &
                                 lossfrac=washfrac, conv=conv)
@@ -318,7 +361,7 @@ CONTAINS
             ENDIF
           ENDIF
 
-        END IF ! DO_WASHOUT .AND. ...
+        END IF ! DO_WASHOUT
 
 
         !---- Perform resuspension of aerosols from evaporating precip. water
@@ -326,9 +369,9 @@ CONTAINS
         ! above
         IF(DO_RESUSPENSION .AND. resusp_frac_1d(k) > LOSSFRAC_MINVAL) THEN
           !-- GOCART: apply resuspension
-          IF(aer_is_gocart .AND. p_chem > param_first_scalar) THEN
+          IF(aer_is_gocart .AND. p_chem >= param_first_scalar) THEN
             ! Resuspend GOCART mass
-            IF(p_chem > param_first_scalar) THEN
+            IF(p_chem >= param_first_scalar) THEN
               resusp_aer = resusp_frac_1d(k) * deposition_flux(iaer) / conv
               chem(i,k,j,p_chem) = MAX(0.0, chem(i,k,j,p_chem) + resusp_aer)
               deposition_flux(iaer) = deposition_flux(iaer) * (1.0 - resusp_frac_1d(k))
@@ -343,7 +386,7 @@ CONTAINS
       !---- Output deposition fluxes
       IF(aer_is_gocart) THEN
         p_chem = aer_pointers(iaer)
-        IF(p_chem > param_first_scalar) THEN
+        IF(p_chem >= param_first_scalar) THEN
           ! WRF-Chem convention is negative from atmosphere to the ground
           qsrflx(i,j,p_chem) = -deposition_flux(iaer)
         ENDIF
@@ -398,8 +441,8 @@ CONTAINS
     IF(cloud_fraction > AERA_FRAC_MINVAL &
        .AND. cloud_water > WATER_MINVAL &
        .AND. rainrate > 0.0) THEN
-      CALL rainfrac_aerosol(rainfrac, frac_rainout, rainrate, dtstep, &
-                            cloud_water)
+      CALL rainfrac_aerosol(rainfrac=rainfrac, frac_rainout=frac_rainout, &
+               rainrate=rainrate, dtstep=dtstep, cloud_water=cloud_water)
     END IF
 
     !-- Scaling factors for cloudborne aerosol uptake efficiency, for rainout
@@ -420,12 +463,11 @@ CONTAINS
         ! Cold clouds - Uptake by homogeneous nucleation = 100%
         cloud_uptk_effic_ice = cloud_fraction
       ELSEIF(tk < 258.0) THEN
-        ! Mixed-phase clouds - Uptake by heterogeneous nucleation
-        cloud_uptk_effic_ice = cloud_fraction
+        ! Mixed-phase clouds - Uptake by heterogeneous nucleation < 100%
         ! Reduce ice-phase scavenging efficiency at warmer temperatures
         ! To take into account the temperature dependence of
         ! heterogeneous nucleation
-        cloud_uptk_effic_ice = cloud_uptk_effic_ice &
+        cloud_uptk_effic_ice = cloud_fraction &
                              * EXP(0.46*(273.16-tk)-11.6)/153.5
         ! Correct by the ice fraction (1.0-liquid_fraction)
         cloud_uptk_effic_ice = MIN(cloud_uptk_effic_ice, &
@@ -578,7 +620,7 @@ CONTAINS
     washfrac = frac_washout * (1.0 - EXP(-lossrate*dtstep))
 
   END SUBROUTINE washfrac_coarse_aerosol
- 
+
 !----------------------------------------------------------------------------
 
   SUBROUTINE remove_aer(aerconc, dep_flux, lossfrac, conv)
@@ -678,20 +720,26 @@ CONTAINS
                            0.078E-6, 0.174E-6, 1.46E-6, 2.8E-6, 4.8E-6, &
                            9.0E-6, 16.0E-6 /)
       ! Fraction of activated aerosols for aer_pointers species
-      ! We do not use the values from Luo et al. (2020) because they are
-      ! mostly sensitive to hygroscopicity, even though size is more important
-      ! for CCN activation
-      ! Instead we assume that only small hygrophobic aerosols (e.g. BC1, OC1)
-      ! are inefficient CCN
-      aq_aer_ratio(:) = (/ 0.5, 0.5, 0.5, 0.5, 0.5, &
-                           0.5, 0.5, 0.5, 0.5, 0.5, &
+      ! Activated fraction in liquid clouds - use values from Grell convection
+      ! wetscav
+      aq_aer_ratio(:) = (/ 1.0, 1.0, 1.0, 1.0, 1.0, &
+                           0.8, 0.8, 0.5, 0.5, 0.5, &
                            0.5, 0.5 /)
-      ! Activated fraction in ice clouds is usually very low except at very low
-      ! temperatures, even for efficient INP - pick 0.5 for now but the true
-      ! value is probably lower
-      ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., &
-                            0., 0., 0.5, 0.5, 0.5, &
-                            0.5, 0.5 /)
+      IF(DO_ICE_RAINOUT) THEN
+        ! Activated fraction in ice clouds is usually very low except close to
+        ! the homogeneous freezing temperature, even for efficient INP
+        ! - Pick 0.5 for dust for now but the true value is probably lower
+        ! - BC is not an efficient INP except at homogeneous freezing
+        !   temperatures but we could also include a tiny fraction
+        ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., &
+                              0., 0., 0.5, 0.5, 0.5, &
+                              0.5, 0.5 /)
+      ELSE
+        ! Disable rainout from ice clouds
+        ice_aer_ratio(:) = (/ 0., 0., 0., 0., 0., &
+                              0., 0., 0., 0., 0., &
+                              0., 0. /)
+      ENDIF
     ELSE
       CALL wrf_error_fatal ('wetscav_simple_init: chem_opt not supported')
     ENDIF

--- a/chem/module_wetscav_driver.F
+++ b/chem/module_wetscav_driver.F
@@ -412,10 +412,9 @@ REAL,  DIMENSION( ims:ime , kms:kme , jms:jme , ntot_amode ),       &
        IF(config_flags%chem_opt == MOZCART_KPP .OR. config_flags%chem_opt == T1_MOZCART_KPP) THEN
          CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
          CALL aer_wetscav_simple(chem=chem, qsrflx=qsrflx, dtstep=dtstep, &
-                                 config_flags=config_flags, t_phy=t_phy, &
-                                 rho_phy=rho_phy, dz8w=dz8w, &
+                                 t_phy=t_phy, rho_phy=rho_phy, dz8w=dz8w, &
                                  cldfra=cldfra_ls, rainprod=rainrate, &
-                                 evapprod=evaprate, &
+                                 evapprod=evaprate, qlsink=qlsink, &
                                  precr=precr, preci=preci, &
                                  precs=precs, precg=precg, &
                                  qc=moist(ims,kms,jms,p_qc), &
@@ -514,10 +513,9 @@ CASE (CBMZ_CAM_MAM3_NOAQ,CBMZ_CAM_MAM3_AQ,CBMZ_CAM_MAM7_NOAQ,CBMZ_CAM_MAM7_AQ)
      endif
      CALL wrf_debug(15,'wetscav_driver calling aer_wetscav_simple')
      CALL aer_wetscav_simple(chem=chem, qsrflx=qsrflx, dtstep=dtstep, &
-                             config_flags=config_flags, t_phy=t_phy, &
-                             rho_phy=rho_phy, dz8w=dz8w, &
+                             t_phy=t_phy, rho_phy=rho_phy, dz8w=dz8w, &
                              cldfra=cldfra_ls, rainprod=rainrate, &
-                             evapprod=evaprate, &
+                             evapprod=evaprate, qlsink=qlsink, &
                              precr=precr, preci=preci, &
                              precs=precs, precg=precg, &
                              qc=moist(ims,kms,jms,p_qc), &


### PR DESCRIPTION
- Use liquid cloud rainout parameters more consistent with mosaic_wetscav and
  convective wetscav in module_cu_gf_ctrans
- Disable rainout from ice clouds in aer_wetscav_simple. The previous
  implementation overestimated scavenging from ice and mixed-phase clouds.
- Disable resuspension from evaporating precipitation, which strongly
  overestimates aerosols at the surface during summer.
- Lowers the resuspension efficiency from 0.5 to 0.1, in case resuspension
  needs to be reactivated.

This fixes issue #114