### PR TITLE
Add an option for leads emission with online lead fraction

### DIFF
--- a/chem/module_seaspray_emis.F
+++ b/chem/module_seaspray_emis.F
@@ -182,6 +182,8 @@ MODULE module_seaspray_emis
     ! low temperatures to ~5.28 at high temperatures, so we chose to adjust
     ! by 1/2.5, which is the ratio in the 10C/20C range
     REAL, PARAMETER :: salter_mode3_corr = 2.5
+    ! Maximum sea ice fraction for treating open ocean fraction in sea ice as leads (unitless, 0-1)
+    REAL, PARAMETER :: SEAICE_LEADS_CRIT = 0.2
     ! Polynomial parameters for the Salter2015 emissions SST factors
     REAL, PARAMETER :: A1=-5.2168E5, B1=3.31725E7, C1=-6.95275E8, D1=1.0684E10
     REAL, PARAMETER :: A2=0.0, B2=7.374E5, C2=-2.4803E7, D2=7.7373E8
@@ -263,9 +265,14 @@ MODULE module_seaspray_emis
           ! Following Lapere et al. (2024)
           leads_to_oo_ratio = 1.0
           !- seas_leads_opt=0 sea_spray*(1-sea_ice) everywhere
-          !- seas_leads_opt=1 Nilsson ratio average in leads
-          lead_frac = leadfrac(i,j)
-          IF ((seas_leads_opt == 1 .AND. lead_frac > 0.0)) THEN
+          !- seas_leads_opt=1 seaspray*lead_frac*leads_to_oo_ratio in leads
+          !- seas_leads_opt=2 sea_spray*(1-sea_ice)*leads_to_oo_ratio where seaice <= SEAICE_LEADS_CRIT
+          IF(seas_leads_opt == 1) THEN
+            lead_frac = leadfrac(i,j)
+          ELSEIF(seas_leads_opt == 2 .AND. open_ocean_frac <= SEAICE_LEADS_CRIT) THEN
+            lead_frac = open_ocean_frac
+          ENDIF
+          IF ((seas_leads_opt == 1 .OR. seas_leads_opt == 2) .AND. lead_frac > 0.0) THEN
              ! oo flux versus lead flux in Nilsson 2001
              leads_to_oo_ratio = EXP(0.11*w10-1.93)/EXP(0.20*w10-1.71)
              ! Recalculate the open ocean fraction to remove the contribution
@@ -318,7 +325,7 @@ MODULE module_seaspray_emis
             ENDIF ! seas_opt
             !---- Correct sea-spray flux by open ocean fraction or open leads
             !  fraction
-            IF(seas_leads_opt == 1 .AND. lead_frac > 0.) THEN
+            IF((seas_leads_opt == 1 .OR. seas_leads_opt == 2) .AND. lead_frac > 0.) THEN
               seaspray_vol_emiss = seaspray_vol_emiss*open_ocean_frac &
                               + seaspray_vol_emiss*leads_to_oo_ratio*lead_frac
             ELSE

--- a/chem/module_seaspray_emis.F
+++ b/chem/module_seaspray_emis.F
@@ -182,7 +182,7 @@ MODULE module_seaspray_emis
     ! low temperatures to ~5.28 at high temperatures, so we chose to adjust
     ! by 1/2.5, which is the ratio in the 10C/20C range
     REAL, PARAMETER :: salter_mode3_corr = 2.5
-    ! Maximum sea ice fraction for treating open ocean fraction in sea ice as leads (unitless, 0-1)
+    ! Maximum open ocean fraction in sea ice for treating open ocean as leads (unitless, 0-1)
     REAL, PARAMETER :: SEAICE_LEADS_CRIT = 0.2
     ! Polynomial parameters for the Salter2015 emissions SST factors
     REAL, PARAMETER :: A1=-5.2168E5, B1=3.31725E7, C1=-6.95275E8, D1=1.0684E10
@@ -266,7 +266,8 @@ MODULE module_seaspray_emis
           leads_to_oo_ratio = 1.0
           !- seas_leads_opt=0 sea_spray*(1-sea_ice) everywhere
           !- seas_leads_opt=1 seaspray*lead_frac*leads_to_oo_ratio in leads
-          !- seas_leads_opt=2 sea_spray*(1-sea_ice)*leads_to_oo_ratio where seaice <= SEAICE_LEADS_CRIT
+          !- seas_leads_opt=2 sea_spray*(1-sea_ice)*leads_to_oo_ratio where
+          !  open ocean <= SEAICE_LEADS_CRIT
           IF(seas_leads_opt == 1) THEN
             lead_frac = leadfrac(i,j)
           ELSEIF(seas_leads_opt == 2 .AND. open_ocean_frac <= SEAICE_LEADS_CRIT) THEN

--- a/polar-options.md
+++ b/polar-options.md
@@ -46,10 +46,11 @@ This option controls the primary sulfate emission in sea-spray. Only compatible 
 This option controls the primary marine organic emissions in sea-spray. Only compatible with seas_opt 5,6,7,8
   - 0 (default): No marine organic emissions from sea-spray
   - 1 (recommended): Marine organic emissions from Vignati et al. (2010). Requires chlorophyll-a input in the wrflowinp file in variable CHLOROA
-### seas_leads_opt (0, 1)
+### seas_leads_opt (0, 1, 2)
 This option controls the sea-spray emissions from sea ice leads. Only compatible with seas_opt 5,6,7,8
   - 0 (default): Sea-spray emissions from leads use the seas_opt source function weighted by the open ocean fraction (1-seaice_concentration)
   - 1: Sea-spray emissions from leads use the seas_opt source function weighted by the leads fraction, also applying a correction factor to reduce the emissions to account for the reduced wind fetch over leads (Lapere et al., 2024). Requires lead fraction input in the wrflowinp file in variable LEADFRAC
+  - 2: Sea-spray emissions from leads use the seas_opt source function weighted by the leads fraction, also applying a correction factor to reduce the emissions to account for the reduced wind fetch over leads (Lapere et al., 2024). Lead fraction is calculated online as 1-seaice where seaice is above 80%, ignoring LEADFRAC even if it is available.
 ### dms_opt (0, 1, 2, 3; previoulsy dmsemis_opt)
 This option controls the treatment of dimethyl sulfide (DMS) emissions from the surface ocean in the model. This replaces the old option dmsemis_opt (deprecated but can still be used if needed). Options 1, 2, and 3 require oceanic DMS concentration input in the wrflowinp file in variable DMS_OCEAN. DMS_OCEAN can be taken from the climatologies of [Lana 2011](https://doi.org/10.1029/2010GB003850), [Hulswar 2021](https://doi.org/10.5194/essd-14-2963-2022) or the CSIB model [(Hayashida et al., 2019)](https://doi.org/10.5194/gmd-12-1965-2019). For options 1, 2, and 3, emissions from sea ice regions are scaled by the open ocean fraction to the power of 0.4 (Loose et al., 2009).
   - 0 (default): No DMS emissions from the ocean surface.


### PR DESCRIPTION
Adds a new namelist option value for emissions from sea ice leads,
seas_leads_opt = 2.
When it is active, the scaling factor for sea spray emissions over sea
ice leads is applied over lead_frac, as in seas_leads_opt = 1, but
lead_frac is not taken from the LEADFRAC input variable but is
recalculated online as 1-SEAICE, where sea ice concentration is greater
than 80%.
Fixes issue #118 